### PR TITLE
fix(ocpi-2.2.1,2.1.1,2.1.1-gireve): receiver should not know sender url before handshake

### DIFF
--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -137,7 +137,7 @@ fun PlatformRepository.tokenFilter(httpRequest: HttpRequest) {
 
     if (!platformExistsWithTokenA(token) &&
         !platformExistsWithTokenB(token) &&
-        getPlatformByTokenC(token) == null
+        getPlatformUrlByTokenC(token) == null
     ) {
         throw OcpiClientInvalidParametersException("Invalid token: $token")
     }

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -135,10 +135,10 @@ fun HttpRequest.parseAuthorizationHeader() = (headers["Authorization"] ?: header
 fun PlatformRepository.tokenFilter(httpRequest: HttpRequest) {
     val token = httpRequest.parseAuthorizationHeader()
 
-    if (getPlatformByTokenA(token) == null &&
-        getPlatformByTokenB(token) == null &&
-        getPlatformByTokenC(token) == null) {
-
+    if (!platformExistsWithTokenA(token) &&
+        !platformExistsWithTokenB(token) &&
+        getPlatformByTokenC(token) == null
+    ) {
         throw OcpiClientInvalidParametersException("Invalid token: $token")
     }
 }

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
@@ -14,7 +14,7 @@ interface PlatformRepository {
     fun getCredentialsTokenC(platformUrl: String): String?
     fun platformExistsWithTokenA(token: String): Boolean
     fun platformExistsWithTokenB(token: String): Boolean
-    fun getPlatformByTokenC(token: String): String?
+    fun getPlatformUrlByTokenC(token: String): String?
     fun getEndpoints(platformUrl: String): List<Endpoint>
     fun getVersion(platformUrl: String): Version?
     fun saveVersion(platformUrl: String, version: Version): Version

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
@@ -12,8 +12,8 @@ interface PlatformRepository {
     fun getCredentialsTokenA(platformUrl: String): String?
     fun getCredentialsTokenB(platformUrl: String): String?
     fun getCredentialsTokenC(platformUrl: String): String?
-    fun getPlatformByTokenA(token: String): String?
-    fun getPlatformByTokenB(token: String): String?
+    fun platformExistsWithTokenA(token: String): Boolean
+    fun platformExistsWithTokenB(token: String): Boolean
     fun getPlatformByTokenC(token: String): String?
     fun getEndpoints(platformUrl: String): List<Endpoint>
     fun getVersion(platformUrl: String): Version?

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
@@ -18,6 +18,7 @@ interface PlatformRepository {
     fun getEndpoints(platformUrl: String): List<Endpoint>
     fun getVersion(platformUrl: String): Version?
     fun saveVersion(platformUrl: String, version: Version): Version
+    fun savePlatformUrlForTokenA(tokenA: String, platformUrl: String): String?
     fun saveEndpoints(platformUrl: String, endpoints: List<Endpoint>): List<Endpoint>
     fun saveCredentialsTokenA(platformUrl: String, credentialsTokenA: String): String
     fun saveCredentialsTokenB(platformUrl: String, credentialsTokenB: String): String

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
@@ -38,8 +38,10 @@ class CredentialsServerService(
         tokenA: String,
         credentials: Credentials
     ): OcpiResponseBody<Credentials> = OcpiResponseBody.of {
-        val platformUrl = platformRepository.getPlatformByTokenA(tokenA)
-            ?: throw OcpiClientInvalidParametersException("Invalid CREDENTIALS_TOKEN_A ($tokenA)")
+        val platformUrl = platformRepository.savePlatformUrlForTokenA(
+            tokenA = tokenA,
+            platformUrl = credentials.url
+        ) ?: throw OcpiClientInvalidParametersException("Invalid CREDENTIALS_TOKEN_A ($tokenA)")
 
         platformRepository.saveCredentialsTokenB(platformUrl = credentials.url, credentialsTokenB = credentials.token)
 

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
@@ -22,7 +22,7 @@ class CredentialsServerService(
         tokenC: String
     ): OcpiResponseBody<Credentials> = OcpiResponseBody.of {
         platformRepository
-            .getPlatformByTokenC(tokenC)
+            .getPlatformUrlByTokenC(tokenC)
             ?.let { platformUrl ->
                 getCredentials(
                     token = platformRepository.getCredentialsTokenC(platformUrl)
@@ -62,7 +62,7 @@ class CredentialsServerService(
         tokenC: String
     ): OcpiResponseBody<Credentials?> = OcpiResponseBody.of {
         platformRepository
-            .getPlatformByTokenC(tokenC)
+            .getPlatformUrlByTokenC(tokenC)
             ?.also { platformUrl ->
                 platformRepository.removeVersion(platformUrl = platformUrl)
                 platformRepository.removeEndpoints(platformUrl = platformUrl)

--- a/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/DummyPlatformCacheRepository.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/DummyPlatformCacheRepository.kt
@@ -2,7 +2,7 @@ package com.izivia.ocpi.toolkit.samples.common
 
 class DummyPlatformCacheRepository(private val tokenC: String): com.izivia.ocpi.toolkit.samples.common.PlatformCacheRepository() {
 
-    override fun getPlatformByTokenC(token: String): String? = super.getPlatformByTokenC(token)
+    override fun getPlatformUrlByTokenC(token: String): String? = super.getPlatformUrlByTokenC(token)
         ?: (if (token == tokenC) "*" else null)
 
     override fun getCredentialsTokenC(platformUrl: String): String = super.getCredentialsTokenC(platformUrl)

--- a/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Platform.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Platform.kt
@@ -4,7 +4,7 @@ import com.izivia.ocpi.toolkit.modules.versions.domain.Endpoint
 import com.izivia.ocpi.toolkit.modules.versions.domain.Version
 
 data class Platform(
-    val url: String,
+    val url: String? = null,
     val version: Version? = null,
     val endpoints: List<Endpoint>? = null,
     val tokenA: String? = null,

--- a/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
@@ -67,7 +67,7 @@ open class PlatformCacheRepository : PlatformRepository {
     override fun platformExistsWithTokenB(token: String): Boolean = platforms
         .any { it.tokenB == token }
 
-    override fun getPlatformByTokenC(token: String): String? = platforms
+    override fun getPlatformUrlByTokenC(token: String): String? = platforms
         .firstOrNull { it.tokenC == token }?.url
 
     override fun getEndpoints(platformUrl: String): List<Endpoint> = platforms

--- a/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
@@ -4,45 +4,55 @@ import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformReposito
 import com.izivia.ocpi.toolkit.modules.versions.domain.Endpoint
 import com.izivia.ocpi.toolkit.modules.versions.domain.Version
 
-open class PlatformCacheRepository: PlatformRepository {
-    val platforms = mutableMapOf<String, Platform>()
+open class PlatformCacheRepository : PlatformRepository {
+    val platforms = mutableListOf<Platform>()
+
+    private fun List<Platform>.getOrDefault(url: String, platform: Platform): Platform =
+        platforms[url] ?: platform
+
+    private operator fun List<Platform>.get(url: String): Platform? =
+        platforms.firstOrNull { it.url == url }
+
+    private operator fun List<Platform>.set(url: String, platform: Platform) {
+        platforms.removeAll { it.url == url }
+        platforms.add(platform)
+    }
 
     override fun savePlatformUrlForTokenA(tokenA: String, platformUrl: String): String? = platforms
         .toList()
-        .firstOrNull { it.second.tokenA == tokenA }
-        ?.second
+        .firstOrNull { it.tokenA == tokenA }
         ?.copy(url = platformUrl)
-        ?.also { platforms[it.url] = it }
+        ?.also { platforms[it.url!!] = it }
         ?.url
 
     override fun saveVersion(platformUrl: String, version: Version): Version = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(version = version)
-        .also { platforms[it.url] = it }
+        .also { platforms[it.url!!] = it }
         .let { it.version!! }
 
     override fun saveEndpoints(platformUrl: String, endpoints: List<Endpoint>): List<Endpoint> = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(endpoints = endpoints)
-        .also { platforms[it.url] = it }
+        .also { platforms[it.url!!] = it }
         .let { it.endpoints!! }
 
     override fun saveCredentialsTokenA(platformUrl: String, credentialsTokenA: String): String = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(tokenA = credentialsTokenA)
-        .also { platforms[it.url] = it }
+        .also { platforms[it.url!!] = it }
         .let { it.tokenA!! }
 
     override fun saveCredentialsTokenB(platformUrl: String, credentialsTokenB: String): String = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(tokenB = credentialsTokenB)
-        .also { platforms[it.url] = it }
+        .also { platforms[it.url!!] = it }
         .let { it.tokenB!! }
 
     override fun saveCredentialsTokenC(platformUrl: String, credentialsTokenC: String): String = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(tokenC = credentialsTokenC)
-        .also { platforms[it.url] = it }
+        .also { platforms[it.url!!] = it }
         .let { it.tokenC!! }
 
     override fun getCredentialsTokenC(platformUrl: String): String? = platforms[platformUrl]?.tokenC
@@ -51,53 +61,54 @@ open class PlatformCacheRepository: PlatformRepository {
 
     override fun getCredentialsTokenA(platformUrl: String): String? = platforms[platformUrl]?.tokenA
 
-    override fun getPlatformByTokenA(token: String): String? = platforms
-        .values.firstOrNull { it.tokenA == token }?.url
+    override fun platformExistsWithTokenA(token: String): Boolean = platforms
+        .any { it.tokenA == token }
 
-    override fun getPlatformByTokenB(token: String): String? = platforms
-        .values.firstOrNull { it.tokenB == token }?.url
+    override fun platformExistsWithTokenB(token: String): Boolean = platforms
+        .any { it.tokenB == token }
 
     override fun getPlatformByTokenC(token: String): String? = platforms
-        .values.firstOrNull { it.tokenC == token }?.url
+        .firstOrNull { it.tokenC == token }?.url
 
     override fun getEndpoints(platformUrl: String): List<Endpoint> = platforms
-        .values.firstOrNull { it.url == platformUrl }?.endpoints ?: emptyList()
+        .firstOrNull { it.url == platformUrl }?.endpoints ?: emptyList()
 
     override fun getVersion(platformUrl: String): Version? = platforms
-        .values.firstOrNull { it.url == platformUrl }?.version
+        .firstOrNull { it.url == platformUrl }?.version
 
     override fun removeCredentialsTokenA(platformUrl: String) {
         platforms
             .getOrDefault(platformUrl, Platform(platformUrl))
             .copy(tokenA = null)
-            .also { platforms[it.url] = it }
+            .also { platforms[it.url!!] = it }
     }
 
     override fun removeCredentialsTokenB(platformUrl: String) {
         platforms
             .getOrDefault(platformUrl, Platform(platformUrl))
             .copy(tokenB = null)
-            .also { platforms[it.url] = it }
+            .also { platforms[it.url!!] = it }
     }
 
     override fun removeCredentialsTokenC(platformUrl: String) {
         platforms
             .getOrDefault(platformUrl, Platform(platformUrl))
             .copy(tokenC = null)
-            .also { platforms[it.url] = it }
+            .also { platforms[it.url!!] = it }
     }
 
     override fun removeVersion(platformUrl: String) {
         platforms
             .getOrDefault(platformUrl, Platform(platformUrl))
             .copy(version = null)
-            .also { platforms[it.url] = it }
+            .also { platforms[it.url!!] = it }
     }
 
     override fun removeEndpoints(platformUrl: String) {
         platforms
             .getOrDefault(platformUrl, Platform(platformUrl))
             .copy(endpoints = null)
-            .also { platforms[it.url] = it }
+            .also { platforms[it.url!!] = it }
     }
 }
+

--- a/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
@@ -7,6 +7,14 @@ import com.izivia.ocpi.toolkit.modules.versions.domain.Version
 open class PlatformCacheRepository: PlatformRepository {
     val platforms = mutableMapOf<String, Platform>()
 
+    override fun savePlatformUrlForTokenA(tokenA: String, platformUrl: String): String? = platforms
+        .toList()
+        .firstOrNull { it.second.tokenA == tokenA }
+        ?.second
+        ?.copy(url = platformUrl)
+        ?.also { platforms[it.url] = it }
+        ?.url
+
     override fun saveVersion(platformUrl: String, version: Version): Version = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(version = version)

--- a/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsReceiver.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsReceiver.kt
@@ -7,6 +7,7 @@ import com.izivia.ocpi.toolkit.modules.versions.VersionsServer
 import com.izivia.ocpi.toolkit.modules.versions.validation.VersionDetailsValidationService
 import com.izivia.ocpi.toolkit.modules.versions.validation.VersionsValidationService
 import com.izivia.ocpi.toolkit.samples.common.*
+import java.util.*
 
 const val receiverPort = 8080
 const val receiverUrl = "http://localhost:$receiverPort"
@@ -18,7 +19,8 @@ fun main() {
 
     // Add token A associated with the sender
     val receiverPlatformRepository = PlatformCacheRepository()
-    receiverPlatformRepository.platforms[senderVersionsUrl] = Platform(url = senderVersionsUrl, tokenA = tokenA)
+    val tempUrl = UUID.randomUUID().toString()
+    receiverPlatformRepository.platforms[tempUrl] = Platform(url = tempUrl, tokenA = tokenA)
 
     com.izivia.ocpi.toolkit.modules.credentials.CredentialsServer(
         transportServer = receiverServer,

--- a/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsReceiver.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsReceiver.kt
@@ -7,7 +7,6 @@ import com.izivia.ocpi.toolkit.modules.versions.VersionsServer
 import com.izivia.ocpi.toolkit.modules.versions.validation.VersionDetailsValidationService
 import com.izivia.ocpi.toolkit.modules.versions.validation.VersionsValidationService
 import com.izivia.ocpi.toolkit.samples.common.*
-import java.util.*
 
 const val receiverPort = 8080
 const val receiverUrl = "http://localhost:$receiverPort"
@@ -15,12 +14,14 @@ const val receiverVersionsUrl = "http://localhost:$receiverPort/versions"
 const val tokenA = "06f7967e-65c3-4def-a966-701ffb362b3c"
 
 fun main() {
-    val receiverServer = Http4kTransportServer(baseUrl = receiverUrl, port = receiverPort)
-
     // Add token A associated with the sender
     val receiverPlatformRepository = PlatformCacheRepository()
-    val tempUrl = UUID.randomUUID().toString()
-    receiverPlatformRepository.platforms[tempUrl] = Platform(url = tempUrl, tokenA = tokenA)
+    receiverPlatformRepository.platforms.add(Platform(tokenA = tokenA))
+
+    val receiverServer = Http4kTransportServer(
+        baseUrl = receiverUrl,
+        port = receiverPort
+    )
 
     com.izivia.ocpi.toolkit.modules.credentials.CredentialsServer(
         transportServer = receiverServer,

--- a/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsSender.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsSender.kt
@@ -20,7 +20,7 @@ fun main() {
     val senderVersionsRepository = VersionsCacheRepository(baseUrl = senderUrl)
     val senderVersionDetailsRepository = VersionDetailsCacheRepository(baseUrl = senderUrl)
     val senderPlatformRepository = PlatformCacheRepository()
-    senderPlatformRepository.platforms[receiverVersionsUrl] = Platform(url = receiverVersionsUrl, tokenA = tokenA)
+    senderPlatformRepository.platforms.add(Platform(url = receiverVersionsUrl, tokenA = tokenA))
 
     VersionsServer(
         transportServer = senderServer,

--- a/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
@@ -62,11 +62,11 @@ class PlatformMongoRepository(
     override fun getCredentialsTokenC(platformUrl: String): String? = collection
         .findOne(Platform::url eq platformUrl)?.tokenC
 
-    override fun getPlatformByTokenA(token: String): String? = collection
-        .findOne(Platform::tokenA eq token)?.url
+    override fun platformExistsWithTokenA(token: String): Boolean = collection
+        .findOne(Platform::tokenA eq token) != null
 
-    override fun getPlatformByTokenB(token: String): String? = collection
-        .findOne(Platform::tokenB eq token)?.url
+    override fun platformExistsWithTokenB(token: String): Boolean = collection
+        .findOne(Platform::tokenB eq token) != null
 
     override fun getPlatformByTokenC(token: String): String? = collection
         .findOne(Platform::tokenC eq token)?.url

--- a/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
@@ -68,7 +68,7 @@ class PlatformMongoRepository(
     override fun platformExistsWithTokenB(token: String): Boolean = collection
         .findOne(Platform::tokenB eq token) != null
 
-    override fun getPlatformByTokenC(token: String): String? = collection
+    override fun getPlatformUrlByTokenC(token: String): String? = collection
         .findOne(Platform::tokenC eq token)?.url
 
     override fun getEndpoints(platformUrl: String): List<Endpoint> = collection

--- a/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
@@ -5,6 +5,8 @@ import com.izivia.ocpi.toolkit.modules.versions.domain.Endpoint
 import com.izivia.ocpi.toolkit.modules.versions.domain.Version
 import com.izivia.ocpi.toolkit.samples.common.Platform
 import com.mongodb.client.MongoCollection
+import com.mongodb.client.model.FindOneAndUpdateOptions
+import com.mongodb.client.model.ReturnDocument
 import org.litote.kmongo.eq
 import org.litote.kmongo.findOne
 import org.litote.kmongo.set
@@ -13,6 +15,16 @@ import org.litote.kmongo.setTo
 class PlatformMongoRepository(
     private val collection: MongoCollection<Platform>
 ) : PlatformRepository {
+
+    override fun savePlatformUrlForTokenA(tokenA: String, platformUrl: String): String? =
+        collection
+            .findOneAndUpdate(
+                Platform::tokenA eq tokenA,
+                set(Platform::url setTo platformUrl),
+                FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER)
+            )
+            ?.url
+
     override fun saveVersion(platformUrl: String, version: Version): Version = version.also {
         collection
             .updateOne(Platform::url eq platformUrl, set(Platform::version setTo it))

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -135,8 +135,8 @@ fun HttpRequest.parseAuthorizationHeader() = (headers["Authorization"] ?: header
 fun PlatformRepository.tokenFilter(httpRequest: HttpRequest) {
     val token = httpRequest.parseAuthorizationHeader()
 
-    if (getPlatformByTokenA(token) == null &&
-        getPlatformByTokenB(token) == null &&
+    if (!platformExistsWithTokenA(token) &&
+        !platformExistsWithTokenB(token) &&
         getPlatformByTokenC(token) == null) {
 
         throw OcpiClientInvalidParametersException("Invalid token: $token")

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -137,7 +137,7 @@ fun PlatformRepository.tokenFilter(httpRequest: HttpRequest) {
 
     if (!platformExistsWithTokenA(token) &&
         !platformExistsWithTokenB(token) &&
-        getPlatformByTokenC(token) == null) {
+        getPlatformUrlByTokenC(token) == null) {
 
         throw OcpiClientInvalidParametersException("Invalid token: $token")
     }

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
@@ -12,8 +12,8 @@ interface PlatformRepository {
     fun getCredentialsTokenA(platformUrl: String): String?
     fun getCredentialsTokenB(platformUrl: String): String?
     fun getCredentialsTokenC(platformUrl: String): String?
-    fun getPlatformByTokenA(token: String): String?
-    fun getPlatformByTokenB(token: String): String?
+    fun platformExistsWithTokenA(token: String): Boolean
+    fun platformExistsWithTokenB(token: String): Boolean
     fun getPlatformByTokenC(token: String): String?
     fun getEndpoints(platformUrl: String): List<Endpoint>
     fun getVersion(platformUrl: String): Version?

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
@@ -14,7 +14,7 @@ interface PlatformRepository {
     fun getCredentialsTokenC(platformUrl: String): String?
     fun platformExistsWithTokenA(token: String): Boolean
     fun platformExistsWithTokenB(token: String): Boolean
-    fun getPlatformByTokenC(token: String): String?
+    fun getPlatformUrlByTokenC(token: String): String?
     fun getEndpoints(platformUrl: String): List<Endpoint>
     fun getVersion(platformUrl: String): Version?
     fun savePlatformUrlForTokenA(tokenA: String, platformUrl: String): String?

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
@@ -17,6 +17,7 @@ interface PlatformRepository {
     fun getPlatformByTokenC(token: String): String?
     fun getEndpoints(platformUrl: String): List<Endpoint>
     fun getVersion(platformUrl: String): Version?
+    fun savePlatformUrlForTokenA(tokenA: String, platformUrl: String): String?
     fun saveVersion(platformUrl: String, version: Version): Version
     fun saveEndpoints(platformUrl: String, endpoints: List<Endpoint>): List<Endpoint>
     fun saveCredentialsTokenA(platformUrl: String, credentialsTokenA: String): String

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
@@ -39,8 +39,10 @@ class CredentialsServerService(
         tokenA: String,
         credentials: Credentials
     ): OcpiResponseBody<Credentials> = OcpiResponseBody.of {
-        val platformUrl = platformRepository.getPlatformByTokenA(tokenA)
-            ?: throw OcpiClientInvalidParametersException("Invalid CREDENTIALS_TOKEN_A ($tokenA)")
+        val platformUrl = platformRepository.savePlatformUrlForTokenA(
+            tokenA = tokenA,
+            platformUrl = credentials.url
+        ) ?: throw OcpiClientInvalidParametersException("Invalid CREDENTIALS_TOKEN_A ($tokenA)")
 
         platformRepository.saveCredentialsTokenB(platformUrl = credentials.url, credentialsTokenB = credentials.token)
 

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
@@ -23,7 +23,7 @@ class CredentialsServerService(
         tokenC: String
     ): OcpiResponseBody<Credentials> = OcpiResponseBody.of {
         platformRepository
-            .getPlatformByTokenC(tokenC)
+            .getPlatformUrlByTokenC(tokenC)
             ?.let { platformUrl ->
                 getCredentials(
                     token = platformRepository.getCredentialsTokenC(platformUrl)
@@ -60,7 +60,7 @@ class CredentialsServerService(
     }
 
     override fun put(tokenC: String, credentials: Credentials): OcpiResponseBody<Credentials> = OcpiResponseBody.of {
-        val platformUrl = platformRepository.getPlatformByTokenC(tokenC)
+        val platformUrl = platformRepository.getPlatformUrlByTokenC(tokenC)
             ?: throw OcpiClientInvalidParametersException("Invalid CREDENTIALS_TOKEN_C ($tokenC)")
 
         platformRepository.saveCredentialsTokenB(platformUrl = credentials.url, credentialsTokenB = credentials.token)
@@ -82,7 +82,7 @@ class CredentialsServerService(
         tokenC: String
     ): OcpiResponseBody<Credentials?> = OcpiResponseBody.of {
         platformRepository
-            .getPlatformByTokenC(tokenC)
+            .getPlatformUrlByTokenC(tokenC)
             ?.also { platformUrl ->
                 platformRepository.removeVersion(platformUrl = platformUrl)
                 platformRepository.removeEndpoints(platformUrl = platformUrl)

--- a/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/DummyPlatformCacheRepository.kt
+++ b/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/DummyPlatformCacheRepository.kt
@@ -2,7 +2,7 @@ package com.izivia.ocpi.toolkit.samples.common
 
 class DummyPlatformCacheRepository(private val tokenC: String): PlatformCacheRepository() {
 
-    override fun getPlatformByTokenC(token: String): String? = super.getPlatformByTokenC(token)
+    override fun getPlatformUrlByTokenC(token: String): String? = super.getPlatformUrlByTokenC(token)
         ?: (if (token == tokenC) "*" else null)
 
     override fun getCredentialsTokenC(platformUrl: String): String = super.getCredentialsTokenC(platformUrl)

--- a/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Platform.kt
+++ b/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Platform.kt
@@ -4,7 +4,7 @@ import com.izivia.ocpi.toolkit.modules.versions.domain.Endpoint
 import com.izivia.ocpi.toolkit.modules.versions.domain.Version
 
 data class Platform(
-    val url: String,
+    val url: String? = null,
     val version: Version? = null,
     val endpoints: List<Endpoint>? = null,
     val tokenA: String? = null,

--- a/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
+++ b/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
@@ -67,7 +67,7 @@ open class PlatformCacheRepository : PlatformRepository {
     override fun platformExistsWithTokenB(token: String): Boolean = platforms
         .any { it.tokenB == token }
 
-    override fun getPlatformByTokenC(token: String): String? = platforms
+    override fun getPlatformUrlByTokenC(token: String): String? = platforms
         .firstOrNull { it.tokenC == token }?.url
 
     override fun getEndpoints(platformUrl: String): List<Endpoint> = platforms

--- a/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
+++ b/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
@@ -7,6 +7,14 @@ import com.izivia.ocpi.toolkit.modules.versions.domain.Version
 open class PlatformCacheRepository: PlatformRepository {
     val platforms = mutableMapOf<String, Platform>()
 
+    override fun savePlatformUrlForTokenA(tokenA: String, platformUrl: String): String? = platforms
+        .toList()
+        .firstOrNull { it.second.tokenA == tokenA }
+        ?.second
+        ?.copy(url = platformUrl)
+        ?.also { platforms[it.url] = it }
+        ?.url
+
     override fun saveVersion(platformUrl: String, version: Version): Version = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(version = version)

--- a/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
+++ b/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
@@ -4,45 +4,55 @@ import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformReposito
 import com.izivia.ocpi.toolkit.modules.versions.domain.Endpoint
 import com.izivia.ocpi.toolkit.modules.versions.domain.Version
 
-open class PlatformCacheRepository: PlatformRepository {
-    val platforms = mutableMapOf<String, Platform>()
+open class PlatformCacheRepository : PlatformRepository {
+    val platforms = mutableListOf<Platform>()
+
+    private fun List<Platform>.getOrDefault(url: String, platform: Platform): Platform =
+        platforms[url] ?: platform
+
+    private operator fun List<Platform>.get(url: String): Platform? =
+        platforms.firstOrNull { it.url == url }
+
+    private operator fun List<Platform>.set(url: String, platform: Platform) {
+        platforms.removeAll { it.url == url }
+        platforms.add(platform)
+    }
 
     override fun savePlatformUrlForTokenA(tokenA: String, platformUrl: String): String? = platforms
         .toList()
-        .firstOrNull { it.second.tokenA == tokenA }
-        ?.second
+        .firstOrNull { it.tokenA == tokenA }
         ?.copy(url = platformUrl)
-        ?.also { platforms[it.url] = it }
+        ?.also { platforms[it.url!!] = it }
         ?.url
 
     override fun saveVersion(platformUrl: String, version: Version): Version = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(version = version)
-        .also { platforms[it.url] = it }
+        .also { platforms[it.url!!] = it }
         .let { it.version!! }
 
     override fun saveEndpoints(platformUrl: String, endpoints: List<Endpoint>): List<Endpoint> = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(endpoints = endpoints)
-        .also { platforms[it.url] = it }
+        .also { platforms[it.url!!] = it }
         .let { it.endpoints!! }
 
     override fun saveCredentialsTokenA(platformUrl: String, credentialsTokenA: String): String = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(tokenA = credentialsTokenA)
-        .also { platforms[it.url] = it }
+        .also { platforms[it.url!!] = it }
         .let { it.tokenA!! }
 
     override fun saveCredentialsTokenB(platformUrl: String, credentialsTokenB: String): String = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(tokenB = credentialsTokenB)
-        .also { platforms[it.url] = it }
+        .also { platforms[it.url!!] = it }
         .let { it.tokenB!! }
 
     override fun saveCredentialsTokenC(platformUrl: String, credentialsTokenC: String): String = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(tokenC = credentialsTokenC)
-        .also { platforms[it.url] = it }
+        .also { platforms[it.url!!] = it }
         .let { it.tokenC!! }
 
     override fun getCredentialsTokenC(platformUrl: String): String? = platforms[platformUrl]?.tokenC
@@ -51,53 +61,53 @@ open class PlatformCacheRepository: PlatformRepository {
 
     override fun getCredentialsTokenA(platformUrl: String): String? = platforms[platformUrl]?.tokenA
 
-    override fun getPlatformByTokenA(token: String): String? = platforms
-        .values.firstOrNull { it.tokenA == token }?.url
+    override fun platformExistsWithTokenA(token: String): Boolean = platforms
+        .any { it.tokenA == token }
 
-    override fun getPlatformByTokenB(token: String): String? = platforms
-        .values.firstOrNull { it.tokenB == token }?.url
+    override fun platformExistsWithTokenB(token: String): Boolean = platforms
+        .any { it.tokenB == token }
 
     override fun getPlatformByTokenC(token: String): String? = platforms
-        .values.firstOrNull { it.tokenC == token }?.url
+        .firstOrNull { it.tokenC == token }?.url
 
     override fun getEndpoints(platformUrl: String): List<Endpoint> = platforms
-        .values.firstOrNull { it.url == platformUrl }?.endpoints ?: emptyList()
+        .firstOrNull { it.url == platformUrl }?.endpoints ?: emptyList()
 
     override fun getVersion(platformUrl: String): Version? = platforms
-        .values.firstOrNull { it.url == platformUrl }?.version
+        .firstOrNull { it.url == platformUrl }?.version
 
     override fun removeCredentialsTokenA(platformUrl: String) {
         platforms
             .getOrDefault(platformUrl, Platform(platformUrl))
             .copy(tokenA = null)
-            .also { platforms[it.url] = it }
+            .also { platforms[it.url!!] = it }
     }
 
     override fun removeCredentialsTokenB(platformUrl: String) {
         platforms
             .getOrDefault(platformUrl, Platform(platformUrl))
             .copy(tokenB = null)
-            .also { platforms[it.url] = it }
+            .also { platforms[it.url!!] = it }
     }
 
     override fun removeCredentialsTokenC(platformUrl: String) {
         platforms
             .getOrDefault(platformUrl, Platform(platformUrl))
             .copy(tokenC = null)
-            .also { platforms[it.url] = it }
+            .also { platforms[it.url!!] = it }
     }
 
     override fun removeVersion(platformUrl: String) {
         platforms
             .getOrDefault(platformUrl, Platform(platformUrl))
             .copy(version = null)
-            .also { platforms[it.url] = it }
+            .also { platforms[it.url!!] = it }
     }
 
     override fun removeEndpoints(platformUrl: String) {
         platforms
             .getOrDefault(platformUrl, Platform(platformUrl))
             .copy(endpoints = null)
-            .also { platforms[it.url] = it }
+            .also { platforms[it.url!!] = it }
     }
 }

--- a/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsReceiver.kt
+++ b/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsReceiver.kt
@@ -8,6 +8,7 @@ import com.izivia.ocpi.toolkit.modules.versions.VersionsServer
 import com.izivia.ocpi.toolkit.modules.versions.validation.VersionDetailsValidationService
 import com.izivia.ocpi.toolkit.modules.versions.validation.VersionsValidationService
 import com.izivia.ocpi.toolkit.samples.common.*
+import java.util.*
 
 const val receiverPort = 8080
 const val receiverUrl = "http://localhost:$receiverPort"
@@ -19,7 +20,8 @@ fun main() {
 
     // Add token A associated with the sender
     val receiverPlatformRepository = PlatformCacheRepository()
-    receiverPlatformRepository.platforms[senderVersionsUrl] = Platform(url = senderVersionsUrl, tokenA = tokenA)
+    val tempUrl = UUID.randomUUID().toString()
+    receiverPlatformRepository.platforms[tempUrl] = Platform(url = tempUrl, tokenA = tokenA)
 
     CredentialsServer(
         transportServer = receiverServer,

--- a/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsReceiver.kt
+++ b/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsReceiver.kt
@@ -8,7 +8,6 @@ import com.izivia.ocpi.toolkit.modules.versions.VersionsServer
 import com.izivia.ocpi.toolkit.modules.versions.validation.VersionDetailsValidationService
 import com.izivia.ocpi.toolkit.modules.versions.validation.VersionsValidationService
 import com.izivia.ocpi.toolkit.samples.common.*
-import java.util.*
 
 const val receiverPort = 8080
 const val receiverUrl = "http://localhost:$receiverPort"
@@ -16,12 +15,14 @@ const val receiverVersionsUrl = "http://localhost:$receiverPort/versions"
 const val tokenA = "06f7967e-65c3-4def-a966-701ffb362b3c"
 
 fun main() {
-    val receiverServer = Http4kTransportServer(baseUrl = receiverUrl, port = receiverPort)
-
     // Add token A associated with the sender
     val receiverPlatformRepository = PlatformCacheRepository()
-    val tempUrl = UUID.randomUUID().toString()
-    receiverPlatformRepository.platforms[tempUrl] = Platform(url = tempUrl, tokenA = tokenA)
+    receiverPlatformRepository.platforms.add(Platform(tokenA = tokenA))
+
+    val receiverServer = Http4kTransportServer(
+        baseUrl = receiverUrl,
+        port = receiverPort
+    )
 
     CredentialsServer(
         transportServer = receiverServer,

--- a/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsSender.kt
+++ b/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsSender.kt
@@ -13,14 +13,17 @@ const val senderUrl = "http://localhost:$senderPort"
 const val senderVersionsUrl = "http://localhost:$senderPort/versions"
 
 fun main() {
-    // Server
-    val senderServer = Http4kTransportServer(baseUrl = senderUrl, port = senderPort)
-
     // Add token A associated with the sender
     val senderVersionsRepository = VersionsCacheRepository(baseUrl = senderUrl)
     val senderVersionDetailsRepository = VersionDetailsCacheRepository(baseUrl = senderUrl)
     val senderPlatformRepository = PlatformCacheRepository()
-    senderPlatformRepository.platforms[receiverVersionsUrl] = Platform(url = receiverVersionsUrl, tokenA = tokenA)
+    senderPlatformRepository.platforms.add(Platform(url = receiverVersionsUrl, tokenA = tokenA))
+
+    // Server
+    val senderServer = Http4kTransportServer(
+        baseUrl = senderUrl,
+        port = senderPort
+    )
 
     VersionsServer(
         transportServer = senderServer,

--- a/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
+++ b/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
@@ -62,11 +62,11 @@ class PlatformMongoRepository(
     override fun getCredentialsTokenC(platformUrl: String): String? = collection
         .findOne(Platform::url eq platformUrl)?.tokenC
 
-    override fun getPlatformByTokenA(token: String): String? = collection
-        .findOne(Platform::tokenA eq token)?.url
+    override fun platformExistsWithTokenA(token: String): Boolean = collection
+        .findOne(Platform::tokenA eq token) != null
 
-    override fun getPlatformByTokenB(token: String): String? = collection
-        .findOne(Platform::tokenB eq token)?.url
+    override fun platformExistsWithTokenB(token: String): Boolean = collection
+        .findOne(Platform::tokenB eq token) != null
 
     override fun getPlatformByTokenC(token: String): String? = collection
         .findOne(Platform::tokenC eq token)?.url

--- a/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
+++ b/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
@@ -68,7 +68,7 @@ class PlatformMongoRepository(
     override fun platformExistsWithTokenB(token: String): Boolean = collection
         .findOne(Platform::tokenB eq token) != null
 
-    override fun getPlatformByTokenC(token: String): String? = collection
+    override fun getPlatformUrlByTokenC(token: String): String? = collection
         .findOne(Platform::tokenC eq token)?.url
 
     override fun getEndpoints(platformUrl: String): List<Endpoint> = collection

--- a/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
+++ b/ocpi-toolkit-2.1.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
@@ -5,6 +5,8 @@ import com.izivia.ocpi.toolkit.modules.versions.domain.Endpoint
 import com.izivia.ocpi.toolkit.modules.versions.domain.Version
 import com.izivia.ocpi.toolkit.samples.common.Platform
 import com.mongodb.client.MongoCollection
+import com.mongodb.client.model.FindOneAndUpdateOptions
+import com.mongodb.client.model.ReturnDocument
 import org.litote.kmongo.eq
 import org.litote.kmongo.findOne
 import org.litote.kmongo.set
@@ -13,6 +15,16 @@ import org.litote.kmongo.setTo
 class PlatformMongoRepository(
     private val collection: MongoCollection<Platform>
 ) : PlatformRepository {
+
+    override fun savePlatformUrlForTokenA(tokenA: String, platformUrl: String): String? =
+        collection
+            .findOneAndUpdate(
+                Platform::tokenA eq tokenA,
+                set(Platform::url setTo platformUrl),
+                FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER)
+            )
+            ?.url
+
     override fun saveVersion(platformUrl: String, version: Version): Version = version.also {
         collection
             .updateOne(Platform::url eq platformUrl, set(Platform::version setTo it))

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -203,7 +203,7 @@ suspend fun PlatformRepository.tokenFilter(httpRequest: HttpRequest) {
 
     if (!platformExistsWithTokenA(token) &&
         !platformExistsWithTokenB(token) &&
-        getPlatformByTokenC(token) == null
+        getPlatformUrlByTokenC(token) == null
     ) {
         throw OcpiClientInvalidParametersException("Invalid token: $token")
     }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -201,11 +201,10 @@ fun HttpRequest.parseAuthorizationHeader() = (headers["Authorization"] ?: header
 suspend fun PlatformRepository.tokenFilter(httpRequest: HttpRequest) {
     val token = httpRequest.parseAuthorizationHeader()
 
-    if (getPlatformByTokenA(token) == null &&
-        getPlatformByTokenB(token) == null &&
+    if (!platformExistsWithTokenA(token) &&
+        !platformExistsWithTokenB(token) &&
         getPlatformByTokenC(token) == null
     ) {
-
         throw OcpiClientInvalidParametersException("Invalid token: $token")
     }
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
@@ -12,8 +12,8 @@ interface PlatformRepository {
     suspend fun getCredentialsTokenA(platformUrl: String): String?
     suspend fun getCredentialsTokenB(platformUrl: String): String?
     suspend fun getCredentialsTokenC(platformUrl: String): String?
-    suspend fun getPlatformByTokenA(token: String): String?
-    suspend fun getPlatformByTokenB(token: String): String?
+    suspend fun platformExistsWithTokenA(token: String): Boolean
+    suspend fun platformExistsWithTokenB(token: String): Boolean
     suspend fun getPlatformByTokenC(token: String): String?
     suspend fun getEndpoints(platformUrl: String): List<Endpoint>
     suspend fun getVersion(platformUrl: String): Version?

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
@@ -17,6 +17,7 @@ interface PlatformRepository {
     suspend fun getPlatformByTokenC(token: String): String?
     suspend fun getEndpoints(platformUrl: String): List<Endpoint>
     suspend fun getVersion(platformUrl: String): Version?
+    suspend fun savePlatformUrlForTokenA(tokenA: String, platformUrl: String): String?
     suspend fun saveVersion(platformUrl: String, version: Version): Version
     suspend fun saveEndpoints(platformUrl: String, endpoints: List<Endpoint>): List<Endpoint>
     suspend fun saveCredentialsTokenA(platformUrl: String, credentialsTokenA: String): String

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
@@ -14,7 +14,7 @@ interface PlatformRepository {
     suspend fun getCredentialsTokenC(platformUrl: String): String?
     suspend fun platformExistsWithTokenA(token: String): Boolean
     suspend fun platformExistsWithTokenB(token: String): Boolean
-    suspend fun getPlatformByTokenC(token: String): String?
+    suspend fun getPlatformUrlByTokenC(token: String): String?
     suspend fun getEndpoints(platformUrl: String): List<Endpoint>
     suspend fun getVersion(platformUrl: String): Version?
     suspend fun savePlatformUrlForTokenA(tokenA: String, platformUrl: String): String?

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
@@ -23,7 +23,7 @@ class CredentialsServerService(
         tokenC: String
     ): OcpiResponseBody<Credentials> = OcpiResponseBody.of {
         platformRepository
-            .getPlatformByTokenC(tokenC)
+            .getPlatformUrlByTokenC(tokenC)
             ?.let { platformUrl ->
                 getCredentials(
                     token = platformRepository.getCredentialsTokenC(platformUrl)
@@ -65,7 +65,7 @@ class CredentialsServerService(
         credentials: Credentials,
         debugHeaders: Map<String, String>
     ): OcpiResponseBody<Credentials> = OcpiResponseBody.of {
-        val platformUrl = platformRepository.getPlatformByTokenC(tokenC)
+        val platformUrl = platformRepository.getPlatformUrlByTokenC(tokenC)
             ?: throw OcpiClientInvalidParametersException("Invalid CREDENTIALS_TOKEN_C ($tokenC)")
 
         platformRepository.saveCredentialsTokenB(platformUrl = credentials.url, credentialsTokenB = credentials.token)
@@ -87,7 +87,7 @@ class CredentialsServerService(
         tokenC: String
     ): OcpiResponseBody<Credentials?> = OcpiResponseBody.of {
         platformRepository
-            .getPlatformByTokenC(tokenC)
+            .getPlatformUrlByTokenC(tokenC)
             ?.also { platformUrl ->
                 platformRepository.removeVersion(platformUrl = platformUrl)
                 platformRepository.removeEndpoints(platformUrl = platformUrl)

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
@@ -40,8 +40,10 @@ class CredentialsServerService(
         credentials: Credentials,
         debugHeaders: Map<String, String>
     ): OcpiResponseBody<Credentials> = OcpiResponseBody.of {
-        val platformUrl = platformRepository.getPlatformByTokenA(tokenA)
-            ?: throw OcpiClientInvalidParametersException("Invalid CREDENTIALS_TOKEN_A ($tokenA)")
+        val platformUrl = platformRepository.savePlatformUrlForTokenA(
+            tokenA = tokenA,
+            platformUrl = credentials.url
+        ) ?: throw OcpiClientInvalidParametersException("Invalid CREDENTIALS_TOKEN_A ($tokenA)")
 
         platformRepository.saveCredentialsTokenB(platformUrl = credentials.url, credentialsTokenB = credentials.token)
 

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/DummyPlatformCacheRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/DummyPlatformCacheRepository.kt
@@ -2,7 +2,7 @@ package com.izivia.ocpi.toolkit.samples.common
 
 class DummyPlatformCacheRepository(private val tokenC: String): PlatformCacheRepository() {
 
-    override suspend fun getPlatformByTokenC(token: String): String? = super.getPlatformByTokenC(token)
+    override suspend fun getPlatformUrlByTokenC(token: String): String? = super.getPlatformUrlByTokenC(token)
         ?: (if (token == tokenC) "*" else null)
 
     override suspend fun getCredentialsTokenC(platformUrl: String): String = super.getCredentialsTokenC(platformUrl)

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Platform.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Platform.kt
@@ -4,7 +4,7 @@ import com.izivia.ocpi.toolkit.modules.versions.domain.Endpoint
 import com.izivia.ocpi.toolkit.modules.versions.domain.Version
 
 data class Platform(
-    val url: String,
+    val url: String? = null,
     val version: Version? = null,
     val endpoints: List<Endpoint>? = null,
     val tokenA: String? = null,

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
@@ -7,6 +7,14 @@ import com.izivia.ocpi.toolkit.modules.versions.domain.Version
 open class PlatformCacheRepository: PlatformRepository {
     val platforms = mutableMapOf<String, Platform>()
 
+    override suspend fun savePlatformUrlForTokenA(tokenA: String, platformUrl: String): String? = platforms
+        .toList()
+        .firstOrNull { it.second.tokenA == tokenA }
+        ?.second
+        ?.copy(url = platformUrl)
+        ?.also { platforms[it.url] = it }
+        ?.url
+
     override suspend fun saveVersion(platformUrl: String, version: Version): Version = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(version = version)

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
@@ -67,7 +67,7 @@ open class PlatformCacheRepository : PlatformRepository {
     override suspend fun platformExistsWithTokenB(token: String): Boolean = platforms
         .any { it.tokenB == token }
 
-    override suspend fun getPlatformByTokenC(token: String): String? = platforms
+    override suspend fun getPlatformUrlByTokenC(token: String): String? = platforms
         .firstOrNull { it.tokenC == token }?.url
 
     override suspend fun getEndpoints(platformUrl: String): List<Endpoint> = platforms

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
@@ -4,45 +4,55 @@ import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformReposito
 import com.izivia.ocpi.toolkit.modules.versions.domain.Endpoint
 import com.izivia.ocpi.toolkit.modules.versions.domain.Version
 
-open class PlatformCacheRepository: PlatformRepository {
-    val platforms = mutableMapOf<String, Platform>()
+open class PlatformCacheRepository : PlatformRepository {
+    val platforms = mutableListOf<Platform>()
+
+    private fun List<Platform>.getOrDefault(url: String, platform: Platform): Platform =
+        platforms[url] ?: platform
+
+    private operator fun List<Platform>.get(url: String): Platform? =
+        platforms.firstOrNull { it.url == url }
+
+    private operator fun List<Platform>.set(url: String, platform: Platform) {
+        platforms.removeAll { it.url == url }
+        platforms.add(platform)
+    }
 
     override suspend fun savePlatformUrlForTokenA(tokenA: String, platformUrl: String): String? = platforms
         .toList()
-        .firstOrNull { it.second.tokenA == tokenA }
-        ?.second
+        .firstOrNull { it.tokenA == tokenA }
         ?.copy(url = platformUrl)
-        ?.also { platforms[it.url] = it }
+        ?.also { platforms[it.url!!] = it }
         ?.url
 
     override suspend fun saveVersion(platformUrl: String, version: Version): Version = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(version = version)
-        .also { platforms[it.url] = it }
+        .also { platforms[it.url!!] = it }
         .let { it.version!! }
 
     override suspend fun saveEndpoints(platformUrl: String, endpoints: List<Endpoint>): List<Endpoint> = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(endpoints = endpoints)
-        .also { platforms[it.url] = it }
+        .also { platforms[it.url!!] = it }
         .let { it.endpoints!! }
 
     override suspend fun saveCredentialsTokenA(platformUrl: String, credentialsTokenA: String): String = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(tokenA = credentialsTokenA)
-        .also { platforms[it.url] = it }
+        .also { platforms[it.url!!] = it }
         .let { it.tokenA!! }
 
     override suspend fun saveCredentialsTokenB(platformUrl: String, credentialsTokenB: String): String = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(tokenB = credentialsTokenB)
-        .also { platforms[it.url] = it }
+        .also { platforms[it.url!!] = it }
         .let { it.tokenB!! }
 
     override suspend fun saveCredentialsTokenC(platformUrl: String, credentialsTokenC: String): String = platforms
         .getOrDefault(platformUrl, Platform(platformUrl))
         .copy(tokenC = credentialsTokenC)
-        .also { platforms[it.url] = it }
+        .also { platforms[it.url!!] = it }
         .let { it.tokenC!! }
 
     override suspend fun getCredentialsTokenC(platformUrl: String): String? = platforms[platformUrl]?.tokenC
@@ -51,53 +61,53 @@ open class PlatformCacheRepository: PlatformRepository {
 
     override suspend fun getCredentialsTokenA(platformUrl: String): String? = platforms[platformUrl]?.tokenA
 
-    override suspend fun getPlatformByTokenA(token: String): String? = platforms
-        .values.firstOrNull { it.tokenA == token }?.url
+    override suspend fun platformExistsWithTokenA(token: String): Boolean = platforms
+        .any { it.tokenA == token }
 
-    override suspend fun getPlatformByTokenB(token: String): String? = platforms
-        .values.firstOrNull { it.tokenB == token }?.url
+    override suspend fun platformExistsWithTokenB(token: String): Boolean = platforms
+        .any { it.tokenB == token }
 
     override suspend fun getPlatformByTokenC(token: String): String? = platforms
-        .values.firstOrNull { it.tokenC == token }?.url
+        .firstOrNull { it.tokenC == token }?.url
 
     override suspend fun getEndpoints(platformUrl: String): List<Endpoint> = platforms
-        .values.firstOrNull { it.url == platformUrl }?.endpoints ?: emptyList()
+        .firstOrNull { it.url == platformUrl }?.endpoints ?: emptyList()
 
     override suspend fun getVersion(platformUrl: String): Version? = platforms
-        .values.firstOrNull { it.url == platformUrl }?.version
+        .firstOrNull { it.url == platformUrl }?.version
 
     override suspend fun removeCredentialsTokenA(platformUrl: String) {
         platforms
             .getOrDefault(platformUrl, Platform(platformUrl))
             .copy(tokenA = null)
-            .also { platforms[it.url] = it }
+            .also { platforms[it.url!!] = it }
     }
 
     override suspend fun removeCredentialsTokenB(platformUrl: String) {
         platforms
             .getOrDefault(platformUrl, Platform(platformUrl))
             .copy(tokenB = null)
-            .also { platforms[it.url] = it }
+            .also { platforms[it.url!!] = it }
     }
 
     override suspend fun removeCredentialsTokenC(platformUrl: String) {
         platforms
             .getOrDefault(platformUrl, Platform(platformUrl))
             .copy(tokenC = null)
-            .also { platforms[it.url] = it }
+            .also { platforms[it.url!!] = it }
     }
 
     override suspend fun removeVersion(platformUrl: String) {
         platforms
             .getOrDefault(platformUrl, Platform(platformUrl))
             .copy(version = null)
-            .also { platforms[it.url] = it }
+            .also { platforms[it.url!!] = it }
     }
 
     override suspend fun removeEndpoints(platformUrl: String) {
         platforms
             .getOrDefault(platformUrl, Platform(platformUrl))
             .copy(endpoints = null)
-            .also { platforms[it.url] = it }
+            .also { platforms[it.url!!] = it }
     }
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsReceiver.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsReceiver.kt
@@ -13,7 +13,6 @@ import com.izivia.ocpi.toolkit.modules.versions.services.VersionDetailsService
 import com.izivia.ocpi.toolkit.modules.versions.services.VersionsService
 import com.izivia.ocpi.toolkit.samples.common.*
 import kotlinx.coroutines.runBlocking
-import java.util.*
 
 const val receiverPort = 8080
 const val receiverUrl = "http://localhost:$receiverPort"
@@ -23,8 +22,7 @@ const val tokenA = "06f7967e-65c3-4def-a966-701ffb362b3c"
 fun main() {
     // Add token A associated with the sender
     val receiverPlatformRepository = PlatformCacheRepository()
-    val tempUrl = UUID.randomUUID().toString()
-    receiverPlatformRepository.platforms[tempUrl] = Platform(url = tempUrl, tokenA = tokenA)
+    receiverPlatformRepository.platforms.add(Platform(tokenA = tokenA))
 
     val receiverServer = Http4kTransportServer(
         baseUrl = receiverUrl,

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsReceiver.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsReceiver.kt
@@ -13,6 +13,7 @@ import com.izivia.ocpi.toolkit.modules.versions.services.VersionDetailsService
 import com.izivia.ocpi.toolkit.modules.versions.services.VersionsService
 import com.izivia.ocpi.toolkit.samples.common.*
 import kotlinx.coroutines.runBlocking
+import java.util.*
 
 const val receiverPort = 8080
 const val receiverUrl = "http://localhost:$receiverPort"
@@ -22,7 +23,8 @@ const val tokenA = "06f7967e-65c3-4def-a966-701ffb362b3c"
 fun main() {
     // Add token A associated with the sender
     val receiverPlatformRepository = PlatformCacheRepository()
-    receiverPlatformRepository.platforms[receiverVersionsUrl] = Platform(url = receiverVersionsUrl, tokenA = tokenA)
+    val tempUrl = UUID.randomUUID().toString()
+    receiverPlatformRepository.platforms[tempUrl] = Platform(url = tempUrl, tokenA = tokenA)
 
     val receiverServer = Http4kTransportServer(
         baseUrl = receiverUrl,

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsSender.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsSender.kt
@@ -22,7 +22,7 @@ fun main() {
     val senderVersionsRepository = VersionsCacheRepository(baseUrl = senderUrl)
     val senderVersionDetailsRepository = VersionDetailsCacheRepository(baseUrl = senderUrl)
     val senderPlatformRepository = PlatformCacheRepository()
-    senderPlatformRepository.platforms[receiverVersionsUrl] = Platform(url = receiverVersionsUrl, tokenA = tokenA)
+    senderPlatformRepository.platforms.add(Platform(url = receiverVersionsUrl, tokenA = tokenA))
 
     // Server
     val senderServer = Http4kTransportServer(

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
@@ -5,6 +5,8 @@ import com.izivia.ocpi.toolkit.modules.versions.domain.Endpoint
 import com.izivia.ocpi.toolkit.modules.versions.domain.Version
 import com.izivia.ocpi.toolkit.samples.common.Platform
 import com.mongodb.client.MongoCollection
+import com.mongodb.client.model.FindOneAndUpdateOptions
+import com.mongodb.client.model.ReturnDocument
 import org.litote.kmongo.eq
 import org.litote.kmongo.findOne
 import org.litote.kmongo.set
@@ -13,6 +15,16 @@ import org.litote.kmongo.setTo
 class PlatformMongoRepository(
     private val collection: MongoCollection<Platform>
 ) : PlatformRepository {
+
+    override suspend fun savePlatformUrlForTokenA(tokenA: String, platformUrl: String): String? =
+        collection
+            .findOneAndUpdate(
+                Platform::tokenA eq tokenA,
+                set(Platform::url setTo platformUrl),
+                FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER)
+            )
+            ?.url
+
     override suspend fun saveVersion(platformUrl: String, version: Version): Version = version.also {
         collection
             .updateOne(Platform::url eq platformUrl, set(Platform::version setTo it))

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
@@ -62,11 +62,11 @@ class PlatformMongoRepository(
     override suspend fun getCredentialsTokenC(platformUrl: String): String? = collection
         .findOne(Platform::url eq platformUrl)?.tokenC
 
-    override suspend fun getPlatformByTokenA(token: String): String? = collection
-        .findOne(Platform::tokenA eq token)?.url
+    override suspend fun platformExistsWithTokenA(token: String): Boolean = collection
+        .findOne(Platform::tokenA eq token) != null
 
-    override suspend fun getPlatformByTokenB(token: String): String? = collection
-        .findOne(Platform::tokenB eq token)?.url
+    override suspend fun platformExistsWithTokenB(token: String): Boolean = collection
+        .findOne(Platform::tokenB eq token) != null
 
     override suspend fun getPlatformByTokenC(token: String): String? = collection
         .findOne(Platform::tokenC eq token)?.url

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PlatformMongoRepository.kt
@@ -68,7 +68,7 @@ class PlatformMongoRepository(
     override suspend fun platformExistsWithTokenB(token: String): Boolean = collection
         .findOne(Platform::tokenB eq token) != null
 
-    override suspend fun getPlatformByTokenC(token: String): String? = collection
+    override suspend fun getPlatformUrlByTokenC(token: String): String? = collection
         .findOne(Platform::tokenC eq token)?.url
 
     override suspend fun getEndpoints(platformUrl: String): List<Endpoint> = collection


### PR DESCRIPTION
All OCPI versions are impacted. This is a breaking change that increases compatibility with partners as receiver.

**Purpose**

These changes prevent you, as a receiver, to ask for your partner URL before a handshake. Before these changes, you had to ask for your partner to give you their versions URL so that you can initialize a `Platform` object with both the `url` and the `tokenA`.

Now, as the OCPI protocol states, you just need (as a receiver), to give a `tokenA` to your partner.

**Why these technical changes**

It is now possible that a `Platform` object only contains a token A before handshake. So the code had to be updated accordingly. Before, it was coded following the assumption that a platform must have at least an `url`. On your side, only the `PlatformRepository` has been updated to follow these principles.

After registration, you can be sure that a `Platform` object has **at least** an url. You can code your `PlatformRepository` implementation following this principle.

**Migration guide**

- Implement `savePlatformUrlForTokenA` in `PlatformRepository` implementation. It is used at the start of POST /credentials in receiver to store the sender url that is then used to retrieve `Platform` object.
- Update your implementations of
  - `getPlatformByTokenA` to `platformExistsWithTokenA`, and return a Boolean whether the token A exists or not in your system
  - `getPlatformByTokenB` to `platformExistsWithTokenB`, and return a Boolean whether the token B exists or not in your system
- Rename `getPlatformByTokenC` to `getPlatformUrlByTokenC`. It has been changed for sake of readability

Example for `savePlatformUrlForTokenA`:

```kotlin
collection
    .findOneAndUpdate(
        Platform::tokenA eq tokenA,
        set(Platform::url setTo platformUrl),
        FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER)
    )
    ?.url
```

Example for `platformExistsWithTokenA` (almost the same for `platformExistsWithTokenB`):

```
override suspend fun platformExistsWithTokenA(token: String): Boolean = collection
        .findOne(Platform::tokenA eq token) != null
```