### PR TITLE
fix(ocpi-2.2.1): Add Content-Type header on requests (if needed), on all responses & fixed headers case sensitivity

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1023,6 +1023,7 @@ ij_groovy_while_on_new_line = false
 ij_groovy_wrap_long_lines = false
 
 [{*.gradle.kts,*.kt,*.kts,*.main.kts}]
+ktlint_disabled_rules = no-wildcard-imports, package-name, filename
 ij_kotlin_align_in_columns_case_branch = false
 ij_kotlin_align_multiline_binary_operation = false
 ij_kotlin_align_multiline_extends_list = false

--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@
 
 Open Charge Point Interface (OCPI) java / kotlin library
 
+## Setup
+
+In your `build.gradle.kts`, add:
+```kts
+dependencies {
+    implementation("com.izivia:ocpi-2-2-1:0.0.13")
+    implementation("com.izivia:ocpi-transport:0.0.13")
+
+    // ... other dependencies
+}
+```
+
+To see all available artifacts, go to: https://central.sonatype.com/search?namespace=com.izivia&q=ocpi
+
 ## Usage
 
 ### Server (CPO or eMSP)

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -147,11 +147,14 @@ private fun HttpRequest.withContentTypeHeaderIfNeeded(): HttpRequest =
  * Dev note: When the server does a request (not a response), it must keep the same X-Correlation-ID but generate a new
  * X-Request-ID. So don't call this method in that case.
  */
-fun HttpRequest.withRequiredHeaders(): HttpRequest =
+fun HttpRequest.withRequiredHeaders(
+    requestId: String,
+    correlationId: String
+): HttpRequest =
     withHeaders(
         headers = headers
-            .plus(Header.X_REQUEST_ID to generateUUIDv4Token())
-            .plus(Header.X_CORRELATION_ID to generateUUIDv4Token())
+            .plus(Header.X_REQUEST_ID to requestId)
+            .plus(Header.X_CORRELATION_ID to correlationId)
     ).withContentTypeHeaderIfNeeded()
 
 /**
@@ -173,10 +176,13 @@ fun HttpRequest.withRequiredHeaders(): HttpRequest =
  *
  * @param headers Headers of the caller. It will re-use the X-Correlation-ID header and regenerate X-Request-ID
  */
-fun HttpRequest.withUpdatedRequiredHeaders(headers: Map<String, String>): HttpRequest =
+fun HttpRequest.withUpdatedRequiredHeaders(
+    headers: Map<String, String>,
+    generatedRequestId: String
+): HttpRequest =
     withHeaders(
         headers = headers
-            .plus(Header.X_REQUEST_ID to generateUUIDv4Token())
+            .plus(Header.X_REQUEST_ID to generatedRequestId) // it replaces existing X_REQUEST_ID header
             .plus(
                 Header.X_CORRELATION_ID to (
                     headers.getByNormalizedKey(Header.X_CORRELATION_ID)

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -179,7 +179,7 @@ fun HttpRequest.withUpdatedRequiredHeaders(headers: Map<String, String>): HttpRe
             .plus(Header.X_REQUEST_ID to generateUUIDv4Token())
             .plus(
                 Header.X_CORRELATION_ID to (
-                    getHeader(Header.X_CORRELATION_ID)
+                    headers.getByNormalizedKey(Header.X_CORRELATION_ID)
                         ?: "error - could not get ${Header.X_CORRELATION_ID} header"
                     )
             )
@@ -205,13 +205,19 @@ fun HttpRequest.getDebugHeaders() = listOfNotNull(
  * Returns the value of a header by its key. The key is not case-sensitive.
  */
 fun HttpRequest.getHeader(key: String): String? =
-    headers.mapKeys { it.key.lowercase() }[key.lowercase()]
+    headers.getByNormalizedKey(key)
 
 /**
  * Returns the value of a header by its key. The key is not case-sensitive.
  */
 fun HttpResponse.getHeader(key: String): String? =
-    headers.mapKeys { it.key.lowercase() }[key.lowercase()]
+    headers.getByNormalizedKey(key)
+
+/**
+ *  Returns the value of a map entry by its key. The key is not case-sensitive.
+ */
+fun Map<String, String>.getByNormalizedKey(key: String): String? =
+    mapKeys { it.key.lowercase() }[key.lowercase()]
 
 /**
  * Parses authorization header from the HttpRequest

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiResponseBody.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiResponseBody.kt
@@ -138,7 +138,7 @@ suspend fun <T> HttpRequest.httpResponse(fn: suspend () -> OcpiResponseBody<T>):
                 }
             ),
             headers = getDebugHeaders()
-                .plus("Content-Type" to "application/json")
+                .plus(Header.CONTENT_TYPE to ContentType.APPLICATION_JSON)
         ).let {
             if (isPaginated) {
                 it.copy(

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiResponseBody.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiResponseBody.kt
@@ -138,6 +138,7 @@ suspend fun <T> HttpRequest.httpResponse(fn: suspend () -> OcpiResponseBody<T>):
                 }
             ),
             headers = getDebugHeaders()
+                .plus("Content-Type" to "application/json")
         ).let {
             if (isPaginated) {
                 it.copy(

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/CredentialsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/CredentialsClient.kt
@@ -12,38 +12,54 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
  */
 class CredentialsClient(
     private val transportClient: TransportClient
-): CredentialsInterface {
+) : CredentialsInterface {
 
     override suspend fun get(tokenC: String): OcpiResponseBody<Credentials> =
         transportClient
             .send(
                 HttpRequest(method = HttpMethod.GET)
-                    .withRequiredHeaders()
+                    .withRequiredHeaders(
+                        requestId = transportClient.generateRequestId(),
+                        correlationId = transportClient.generateCorrelationId()
+                    )
                     .authenticate(token = tokenC)
             )
             .parseBody()
 
-
-    override suspend fun post(tokenA: String, credentials: Credentials, debugHeaders: Map<String, String>): OcpiResponseBody<Credentials> =
+    override suspend fun post(
+        tokenA: String,
+        credentials: Credentials,
+        debugHeaders: Map<String, String>
+    ): OcpiResponseBody<Credentials> =
         transportClient
             .send(
                 HttpRequest(
                     method = HttpMethod.POST,
                     body = mapper.writeValueAsString(credentials)
                 )
-                    .withRequiredHeaders()
+                    .withRequiredHeaders(
+                        requestId = transportClient.generateRequestId(),
+                        correlationId = transportClient.generateCorrelationId()
+                    )
                     .authenticate(token = tokenA)
             )
             .parseBody()
 
-    override suspend fun put(tokenC: String, credentials: Credentials, debugHeaders: Map<String, String>): OcpiResponseBody<Credentials> =
+    override suspend fun put(
+        tokenC: String,
+        credentials: Credentials,
+        debugHeaders: Map<String, String>
+    ): OcpiResponseBody<Credentials> =
         transportClient
             .send(
                 HttpRequest(
                     method = HttpMethod.PUT,
                     body = mapper.writeValueAsString(credentials)
                 )
-                    .withRequiredHeaders()
+                    .withRequiredHeaders(
+                        requestId = transportClient.generateRequestId(),
+                        correlationId = transportClient.generateCorrelationId()
+                    )
                     .authenticate(token = tokenC)
             )
             .parseBody()
@@ -52,7 +68,10 @@ class CredentialsClient(
         transportClient
             .send(
                 HttpRequest(method = HttpMethod.DELETE)
-                    .withRequiredHeaders()
+                    .withRequiredHeaders(
+                        requestId = transportClient.generateRequestId(),
+                        correlationId = transportClient.generateCorrelationId()
+                    )
                     .authenticate(token = tokenC)
             )
             .parseBody()

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/CredentialsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/CredentialsClient.kt
@@ -18,7 +18,7 @@ class CredentialsClient(
         transportClient
             .send(
                 HttpRequest(method = HttpMethod.GET)
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(token = tokenC)
             )
             .parseBody()
@@ -31,7 +31,7 @@ class CredentialsClient(
                     method = HttpMethod.POST,
                     body = mapper.writeValueAsString(credentials)
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(token = tokenA)
             )
             .parseBody()
@@ -43,7 +43,7 @@ class CredentialsClient(
                     method = HttpMethod.PUT,
                     body = mapper.writeValueAsString(credentials)
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(token = tokenC)
             )
             .parseBody()
@@ -52,7 +52,7 @@ class CredentialsClient(
         transportClient
             .send(
                 HttpRequest(method = HttpMethod.DELETE)
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(token = tokenC)
             )
             .parseBody()

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
@@ -106,7 +106,7 @@ class CredentialsServerService(
             .build(credentials.url)
             .send(
                 HttpRequest(method = HttpMethod.GET)
-                    .withUpdatedDebugHeaders(headers = debugHeaders)
+                    .withUpdatedRequiredHeaders(headers = debugHeaders)
                     .authenticate(token = credentials.token)
             )
             .parseBody<OcpiResponseBody<List<Version>>>()
@@ -126,7 +126,7 @@ class CredentialsServerService(
             .build(matchingVersion.url)
             .send(
                 HttpRequest(method = HttpMethod.GET)
-                    .withUpdatedDebugHeaders(headers = debugHeaders)
+                    .withUpdatedRequiredHeaders(headers = debugHeaders)
                     .authenticate(token = credentials.token)
             )
             .parseBody<OcpiResponseBody<VersionDetails>>()

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
@@ -104,11 +104,16 @@ class CredentialsServerService(
     ) {
         val versions = transportClientBuilder
             .build(credentials.url)
-            .send(
-                HttpRequest(method = HttpMethod.GET)
-                    .withUpdatedRequiredHeaders(headers = debugHeaders)
-                    .authenticate(token = credentials.token)
-            )
+            .run {
+                send(
+                    HttpRequest(method = HttpMethod.GET)
+                        .withUpdatedRequiredHeaders(
+                            headers = debugHeaders,
+                            generatedRequestId = generateRequestId()
+                        )
+                        .authenticate(token = credentials.token)
+                )
+            }
             .parseBody<OcpiResponseBody<List<Version>>>()
             .let {
                 it.data
@@ -124,11 +129,16 @@ class CredentialsServerService(
 
         val versionDetail = transportClientBuilder
             .build(matchingVersion.url)
-            .send(
-                HttpRequest(method = HttpMethod.GET)
-                    .withUpdatedRequiredHeaders(headers = debugHeaders)
-                    .authenticate(token = credentials.token)
-            )
+            .run {
+                send(
+                    HttpRequest(method = HttpMethod.GET)
+                        .withUpdatedRequiredHeaders(
+                            headers = debugHeaders,
+                            generatedRequestId = generateRequestId()
+                        )
+                        .authenticate(token = credentials.token)
+                )
+            }
             .parseBody<OcpiResponseBody<VersionDetails>>()
             .let {
                 it.data

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
@@ -39,7 +39,7 @@ class LocationsCpoClient(
                     method = HttpMethod.GET,
                     path = "/$countryCode/$partyId/$locationId"
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parseBody()
@@ -56,7 +56,7 @@ class LocationsCpoClient(
                     method = HttpMethod.GET,
                     path = "/$countryCode/$partyId/$locationId/$evseUid"
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parseBody()
@@ -74,7 +74,7 @@ class LocationsCpoClient(
                     method = HttpMethod.GET,
                     path = "/$countryCode/$partyId/$locationId/$evseUid/$connectorId"
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parseBody()
@@ -92,7 +92,7 @@ class LocationsCpoClient(
                     path = "/$countryCode/$partyId/$locationId",
                     body = mapper.writeValueAsString(location)
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parseBody()
@@ -111,7 +111,7 @@ class LocationsCpoClient(
                     path = "/$countryCode/$partyId/$locationId/$evseUid",
                     body = mapper.writeValueAsString(evse)
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parseBody()
@@ -131,7 +131,7 @@ class LocationsCpoClient(
                     path = "/$countryCode/$partyId/$locationId/$evseUid/$connectorId",
                     body = mapper.writeValueAsString(connector)
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parseBody()
@@ -149,7 +149,7 @@ class LocationsCpoClient(
                     path = "/$countryCode/$partyId/$locationId",
                     body = mapper.writeValueAsString(location)
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parseBody()
@@ -168,7 +168,7 @@ class LocationsCpoClient(
                     path = "/$countryCode/$partyId/$locationId",
                     body = mapper.writeValueAsString(evse)
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parseBody()
@@ -188,7 +188,7 @@ class LocationsCpoClient(
                     path = "/$countryCode/$partyId/$locationId",
                     body = mapper.writeValueAsString(connector)
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parseBody()

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
@@ -32,34 +32,40 @@ class LocationsCpoClient(
         countryCode: CiString,
         partyId: CiString,
         locationId: CiString
-    ): OcpiResponseBody<Location?> =
-        buildTransport()
-            .send(
-                HttpRequest(
-                    method = HttpMethod.GET,
-                    path = "/$countryCode/$partyId/$locationId"
-                )
-                    .withRequiredHeaders()
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+    ): OcpiResponseBody<Location?> = with(buildTransport()) {
+        send(
+            HttpRequest(
+                method = HttpMethod.GET,
+                path = "/$countryCode/$partyId/$locationId"
             )
+                .withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
+                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+        )
             .parseBody()
+    }
 
     override suspend fun getEvse(
         countryCode: CiString,
         partyId: CiString,
         locationId: CiString,
         evseUid: CiString
-    ): OcpiResponseBody<Evse?> =
-        buildTransport()
-            .send(
-                HttpRequest(
-                    method = HttpMethod.GET,
-                    path = "/$countryCode/$partyId/$locationId/$evseUid"
-                )
-                    .withRequiredHeaders()
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+    ): OcpiResponseBody<Evse?> = with(buildTransport()) {
+        send(
+            HttpRequest(
+                method = HttpMethod.GET,
+                path = "/$countryCode/$partyId/$locationId/$evseUid"
             )
+                .withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
+                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+        )
             .parseBody()
+    }
 
     override suspend fun getConnector(
         countryCode: CiString,
@@ -67,35 +73,41 @@ class LocationsCpoClient(
         locationId: CiString,
         evseUid: CiString,
         connectorId: CiString
-    ): OcpiResponseBody<Connector?> =
-        buildTransport()
-            .send(
-                HttpRequest(
-                    method = HttpMethod.GET,
-                    path = "/$countryCode/$partyId/$locationId/$evseUid/$connectorId"
-                )
-                    .withRequiredHeaders()
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+    ): OcpiResponseBody<Connector?> = with(buildTransport()) {
+        send(
+            HttpRequest(
+                method = HttpMethod.GET,
+                path = "/$countryCode/$partyId/$locationId/$evseUid/$connectorId"
             )
+                .withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
+                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+        )
             .parseBody()
+    }
 
     override suspend fun putLocation(
         countryCode: CiString,
         partyId: CiString,
         locationId: CiString,
         location: Location
-    ): OcpiResponseBody<Location> =
-        buildTransport()
-            .send(
-                HttpRequest(
-                    method = HttpMethod.PUT,
-                    path = "/$countryCode/$partyId/$locationId",
-                    body = mapper.writeValueAsString(location)
-                )
-                    .withRequiredHeaders()
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+    ): OcpiResponseBody<Location> = with(buildTransport()) {
+        send(
+            HttpRequest(
+                method = HttpMethod.PUT,
+                path = "/$countryCode/$partyId/$locationId",
+                body = mapper.writeValueAsString(location)
             )
+                .withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
+                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+        )
             .parseBody()
+    }
 
     override suspend fun putEvse(
         countryCode: CiString,
@@ -103,18 +115,21 @@ class LocationsCpoClient(
         locationId: CiString,
         evseUid: CiString,
         evse: Evse
-    ): OcpiResponseBody<Evse> =
-        buildTransport()
-            .send(
-                HttpRequest(
-                    method = HttpMethod.PUT,
-                    path = "/$countryCode/$partyId/$locationId/$evseUid",
-                    body = mapper.writeValueAsString(evse)
-                )
-                    .withRequiredHeaders()
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+    ): OcpiResponseBody<Evse> = with(buildTransport()) {
+        send(
+            HttpRequest(
+                method = HttpMethod.PUT,
+                path = "/$countryCode/$partyId/$locationId/$evseUid",
+                body = mapper.writeValueAsString(evse)
             )
+                .withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
+                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+        )
             .parseBody()
+    }
 
     override suspend fun putConnector(
         countryCode: CiString,
@@ -123,36 +138,42 @@ class LocationsCpoClient(
         evseUid: CiString,
         connectorId: CiString,
         connector: Connector
-    ): OcpiResponseBody<Connector> =
-        buildTransport()
-            .send(
-                HttpRequest(
-                    method = HttpMethod.PUT,
-                    path = "/$countryCode/$partyId/$locationId/$evseUid/$connectorId",
-                    body = mapper.writeValueAsString(connector)
-                )
-                    .withRequiredHeaders()
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+    ): OcpiResponseBody<Connector> = with(buildTransport()) {
+        send(
+            HttpRequest(
+                method = HttpMethod.PUT,
+                path = "/$countryCode/$partyId/$locationId/$evseUid/$connectorId",
+                body = mapper.writeValueAsString(connector)
             )
+                .withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
+                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+        )
             .parseBody()
+    }
 
     override suspend fun patchLocation(
         countryCode: CiString,
         partyId: CiString,
         locationId: CiString,
         location: LocationPartial
-    ): OcpiResponseBody<Location?> =
-        buildTransport()
-            .send(
-                HttpRequest(
-                    method = HttpMethod.PATCH,
-                    path = "/$countryCode/$partyId/$locationId",
-                    body = mapper.writeValueAsString(location)
-                )
-                    .withRequiredHeaders()
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+    ): OcpiResponseBody<Location?> = with(buildTransport()) {
+        send(
+            HttpRequest(
+                method = HttpMethod.PATCH,
+                path = "/$countryCode/$partyId/$locationId",
+                body = mapper.writeValueAsString(location)
             )
+                .withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
+                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+        )
             .parseBody()
+    }
 
     override suspend fun patchEvse(
         countryCode: CiString,
@@ -160,18 +181,21 @@ class LocationsCpoClient(
         locationId: CiString,
         evseUid: CiString,
         evse: EvsePartial
-    ): OcpiResponseBody<Evse?> =
-        buildTransport()
-            .send(
-                HttpRequest(
-                    method = HttpMethod.PATCH,
-                    path = "/$countryCode/$partyId/$locationId",
-                    body = mapper.writeValueAsString(evse)
-                )
-                    .withRequiredHeaders()
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+    ): OcpiResponseBody<Evse?> = with(buildTransport()) {
+        send(
+            HttpRequest(
+                method = HttpMethod.PATCH,
+                path = "/$countryCode/$partyId/$locationId",
+                body = mapper.writeValueAsString(evse)
             )
+                .withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
+                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+        )
             .parseBody()
+    }
 
     override suspend fun patchConnector(
         countryCode: CiString,
@@ -180,16 +204,19 @@ class LocationsCpoClient(
         evseUid: CiString,
         connectorId: CiString,
         connector: ConnectorPartial
-    ): OcpiResponseBody<Connector?> =
-        buildTransport()
-            .send(
-                HttpRequest(
-                    method = HttpMethod.PATCH,
-                    path = "/$countryCode/$partyId/$locationId",
-                    body = mapper.writeValueAsString(connector)
-                )
-                    .withRequiredHeaders()
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+    ): OcpiResponseBody<Connector?> = with(buildTransport()) {
+        send(
+            HttpRequest(
+                method = HttpMethod.PATCH,
+                path = "/$countryCode/$partyId/$locationId",
+                body = mapper.writeValueAsString(connector)
             )
+                .withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
+                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+        )
             .parseBody()
+    }
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
@@ -48,7 +48,7 @@ class LocationsEmspClient(
                         limit?.let { "limit" to limit.toString() }
                     ).toMap()
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parsePaginatedBody(offset)
@@ -60,7 +60,7 @@ class LocationsEmspClient(
                     method = HttpMethod.GET,
                     path = "/$locationId",
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parseBody()
@@ -72,7 +72,7 @@ class LocationsEmspClient(
                     method = HttpMethod.GET,
                     path = "/$locationId/$evseUid",
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parseBody()
@@ -88,7 +88,7 @@ class LocationsEmspClient(
                     method = HttpMethod.GET,
                     path = "/$locationId/$evseUid/$connectorId",
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parseBody()

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
@@ -36,60 +36,73 @@ class LocationsEmspClient(
         dateTo: Instant?,
         offset: Int,
         limit: Int?
-    ): OcpiResponseBody<SearchResult<Location>> =
-        buildTransport()
-            .send(
-                HttpRequest(
-                    method = HttpMethod.GET,
-                    queryParams = listOfNotNull(
-                        dateFrom?.let { "date_from" to dateFrom.toString() },
-                        dateTo?.let { "date_to" to dateTo.toString() },
-                        "offset" to offset.toString(),
-                        limit?.let { "limit" to limit.toString() }
-                    ).toMap()
-                )
-                    .withRequiredHeaders()
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+    ): OcpiResponseBody<SearchResult<Location>> = with(buildTransport()) {
+        send(
+            HttpRequest(
+                method = HttpMethod.GET,
+                queryParams = listOfNotNull(
+                    dateFrom?.let { "date_from" to dateFrom.toString() },
+                    dateTo?.let { "date_to" to dateTo.toString() },
+                    "offset" to offset.toString(),
+                    limit?.let { "limit" to limit.toString() }
+                ).toMap()
             )
+                .withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
+                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+        )
             .parsePaginatedBody(offset)
+    }
 
-    override suspend fun getLocation(locationId: CiString): OcpiResponseBody<Location?> =
-        buildTransport()
-            .send(
-                HttpRequest(
-                    method = HttpMethod.GET,
-                    path = "/$locationId",
-                )
-                    .withRequiredHeaders()
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+    override suspend fun getLocation(locationId: CiString): OcpiResponseBody<Location?> = with(buildTransport()) {
+        send(
+            HttpRequest(
+                method = HttpMethod.GET,
+                path = "/$locationId"
             )
+                .withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
+                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+        )
             .parseBody()
+    }
 
     override suspend fun getEvse(locationId: CiString, evseUid: CiString): OcpiResponseBody<Evse?> =
-        buildTransport()
-            .send(
+        with(buildTransport()) {
+            send(
                 HttpRequest(
                     method = HttpMethod.GET,
-                    path = "/$locationId/$evseUid",
+                    path = "/$locationId/$evseUid"
                 )
-                    .withRequiredHeaders()
+                    .withRequiredHeaders(
+                        requestId = generateRequestId(),
+                        correlationId = generateCorrelationId()
+                    )
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
-            .parseBody()
+                .parseBody()
+        }
 
     override suspend fun getConnector(
         locationId: CiString,
         evseUid: CiString,
         connectorId: CiString
-    ): OcpiResponseBody<Connector?> =
-        buildTransport()
-            .send(
-                HttpRequest(
-                    method = HttpMethod.GET,
-                    path = "/$locationId/$evseUid/$connectorId",
-                )
-                    .withRequiredHeaders()
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+    ): OcpiResponseBody<Connector?> = with(buildTransport()) {
+        send(
+            HttpRequest(
+                method = HttpMethod.GET,
+                path = "/$locationId/$evseUid/$connectorId"
             )
+                .withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
+                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+        )
             .parseBody()
+    }
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsCpoClient.kt
@@ -27,16 +27,24 @@ class SessionsCpoClient(
             platformRepository = platformRepository
         )
 
-    override suspend fun getSession(countryCode: CiString, partyId: CiString, sessionId: CiString): OcpiResponseBody<Session> =
-        buildTransport()
-            .send(
+    override suspend fun getSession(
+        countryCode: CiString,
+        partyId: CiString,
+        sessionId: CiString
+    ): OcpiResponseBody<Session> =
+        with(buildTransport()) {
+            send(
                 HttpRequest(
                     method = HttpMethod.GET,
                     path = "/$countryCode/$partyId/$sessionId"
-                ).withRequiredHeaders()
+                ).withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
-            .parseBody()
+                .parseBody()
+        }
 
     override suspend fun putSession(
         countryCode: CiString,
@@ -44,16 +52,20 @@ class SessionsCpoClient(
         sessionId: CiString,
         session: Session
     ): OcpiResponseBody<Session?> =
-        buildTransport()
-            .send(
+        with(buildTransport()) {
+            send(
                 HttpRequest(
                     method = HttpMethod.PUT,
                     path = "/$countryCode/$partyId/$sessionId",
                     body = mapper.writeValueAsString(session)
-                ).withRequiredHeaders()
+                ).withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
-            .parseBody()
+                .parseBody()
+        }
 
     override suspend fun patchSession(
         countryCode: CiString,
@@ -61,14 +73,18 @@ class SessionsCpoClient(
         sessionId: CiString,
         session: Session
     ): OcpiResponseBody<Session?> =
-        buildTransport()
-            .send(
+        with(buildTransport()) {
+            send(
                 HttpRequest(
                     method = HttpMethod.PATCH,
                     path = "/$countryCode/$partyId/$sessionId",
                     body = mapper.writeValueAsString(session)
-                ).withRequiredHeaders()
+                ).withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
-            .parseBody()
+                .parseBody()
+        }
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsCpoClient.kt
@@ -33,7 +33,7 @@ class SessionsCpoClient(
                 HttpRequest(
                     method = HttpMethod.GET,
                     path = "/$countryCode/$partyId/$sessionId"
-                ).withDebugHeaders()
+                ).withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parseBody()
@@ -50,7 +50,7 @@ class SessionsCpoClient(
                     method = HttpMethod.PUT,
                     path = "/$countryCode/$partyId/$sessionId",
                     body = mapper.writeValueAsString(session)
-                ).withDebugHeaders()
+                ).withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parseBody()
@@ -67,7 +67,7 @@ class SessionsCpoClient(
                     method = HttpMethod.PATCH,
                     path = "/$countryCode/$partyId/$sessionId",
                     body = mapper.writeValueAsString(session)
-                ).withDebugHeaders()
+                ).withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parseBody()

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsEmspClient.kt
@@ -46,7 +46,7 @@ class SessionsEmspClient(
                         "offset" to offset.toString(),
                         limit?.let { "limit" to limit.toString() }
                     ).toMap()
-                ).withDebugHeaders()
+                ).withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parsePaginatedBody(offset)
@@ -61,7 +61,7 @@ class SessionsEmspClient(
                     method = HttpMethod.PUT,
                     path = "/$sessionId/charging_preferences",
                     body = mapper.writeValueAsString(chargingPreferences)
-                ).withDebugHeaders()
+                ).withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parseBody()

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsEmspClient.kt
@@ -36,8 +36,8 @@ class SessionsEmspClient(
         offset: Int,
         limit: Int?
     ): OcpiResponseBody<SearchResult<Session>> =
-        buildTransport()
-            .send(
+        with(buildTransport()) {
+            send(
                 HttpRequest(
                     method = HttpMethod.GET,
                     queryParams = listOfNotNull(
@@ -46,23 +46,31 @@ class SessionsEmspClient(
                         "offset" to offset.toString(),
                         limit?.let { "limit" to limit.toString() }
                     ).toMap()
-                ).withRequiredHeaders()
+                ).withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
-            .parsePaginatedBody(offset)
+                .parsePaginatedBody(offset)
+        }
 
     override suspend fun putChargingPreferences(
         sessionId: CiString,
         chargingPreferences: ChargingPreferences
     ): OcpiResponseBody<ChargingPreferencesResponseType> =
-        buildTransport()
-            .send(
+        with(buildTransport()) {
+            send(
                 HttpRequest(
                     method = HttpMethod.PUT,
                     path = "/$sessionId/charging_preferences",
                     body = mapper.writeValueAsString(chargingPreferences)
-                ).withRequiredHeaders()
+                ).withRequiredHeaders(
+                    requestId = generateRequestId(),
+                    correlationId = generateCorrelationId()
+                )
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
-            .parseBody()
+                .parseBody()
+        }
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
@@ -37,8 +37,8 @@ class TokensCpoClient(
         offset: Int,
         limit: Int?
     ): OcpiResponseBody<SearchResult<Token>> =
-        buildTransport()
-            .send(
+        with(buildTransport()) {
+            send(
                 HttpRequest(
                     method = HttpMethod.GET,
                     queryParams = listOfNotNull(
@@ -48,26 +48,33 @@ class TokensCpoClient(
                         limit?.let { "limit" to limit.toString() }
                     ).toMap()
                 )
-                    .withRequiredHeaders()
+                    .withRequiredHeaders(
+                        requestId = generateRequestId(),
+                        correlationId = generateCorrelationId()
+                    )
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
-            .parsePaginatedBody(offset)
-
+                .parsePaginatedBody(offset)
+        }
 
     override suspend fun postToken(
         tokenUid: CiString,
         type: TokenType?,
         locationReferences: LocationReferences?
     ): OcpiResponseBody<AuthorizationInfo> =
-        buildTransport()
-            .send(
+        with(buildTransport()) {
+            send(
                 HttpRequest(
                     method = HttpMethod.POST,
                     path = "/$tokenUid/authorize",
                     queryParams = listOf("type" to type.toString()).toMap(),
                     body = locationReferences.run(mapper::writeValueAsString)
                 )
-                    .withRequiredHeaders()
+                    .withRequiredHeaders(
+                        requestId = generateRequestId(),
+                        correlationId = generateCorrelationId()
+                    )
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             ).parseBody()
+        }
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
@@ -48,7 +48,7 @@ class TokensCpoClient(
                         limit?.let { "limit" to limit.toString() }
                     ).toMap()
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             )
             .parsePaginatedBody(offset)
@@ -67,7 +67,7 @@ class TokensCpoClient(
                     queryParams = listOf("type" to type.toString()).toMap(),
                     body = locationReferences.run(mapper::writeValueAsString)
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             ).parseBody()
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
@@ -36,16 +36,20 @@ class TokensEmspClient(
         tokenUid: CiString,
         type: TokenType?
     ): OcpiResponseBody<Token> =
-        buildTransport()
-            .send(
+        with(buildTransport()) {
+            send(
                 HttpRequest(
                     method = HttpMethod.GET,
                     path = "/$countryCode/$partyId/$tokenUid",
                     queryParams = listOfNotNull(type?.let { "type" to type.toString() }).toMap()
                 )
-                    .withRequiredHeaders()
+                    .withRequiredHeaders(
+                        requestId = generateRequestId(),
+                        correlationId = generateCorrelationId()
+                    )
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             ).parseBody()
+        }
 
     override suspend fun putToken(
         token: Token,
@@ -54,8 +58,8 @@ class TokensEmspClient(
         tokenUid: CiString,
         type: TokenType?
     ): OcpiResponseBody<Token> =
-        buildTransport()
-            .send(
+        with(buildTransport()) {
+            send(
                 HttpRequest(
                     method = HttpMethod.PUT,
                     body = mapper.writeValueAsString(token),
@@ -63,12 +67,16 @@ class TokensEmspClient(
                         "country_code" to countryCode,
                         "party_id" to partyId,
                         "token_uid" to tokenUid,
-                        type?.let { "type" to type.toString() }).toMap()
+                        type?.let { "type" to type.toString() }
+                    ).toMap()
                 )
-                    .withRequiredHeaders()
+                    .withRequiredHeaders(
+                        requestId = generateRequestId(),
+                        correlationId = generateCorrelationId()
+                    )
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             ).parseBody()
-
+        }
 
     override suspend fun patchToken(
         token: TokenPartial,
@@ -77,8 +85,8 @@ class TokensEmspClient(
         tokenUid: CiString,
         type: TokenType?
     ): OcpiResponseBody<Token?> =
-        buildTransport()
-            .send(
+        with(buildTransport()) {
+            send(
                 HttpRequest(
                     method = HttpMethod.PATCH,
                     body = mapper.writeValueAsString(token),
@@ -86,9 +94,14 @@ class TokensEmspClient(
                         "country_code" to countryCode,
                         "party_id" to partyId,
                         "token_uid" to tokenUid,
-                        type?.let { "type" to type.toString() }).toMap()
+                        type?.let { "type" to type.toString() }
+                    ).toMap()
                 )
-                    .withRequiredHeaders()
+                    .withRequiredHeaders(
+                        requestId = generateRequestId(),
+                        correlationId = generateCorrelationId()
+                    )
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             ).parseBody()
+        }
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
@@ -43,7 +43,7 @@ class TokensEmspClient(
                     path = "/$countryCode/$partyId/$tokenUid",
                     queryParams = listOfNotNull(type?.let { "type" to type.toString() }).toMap()
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             ).parseBody()
 
@@ -65,7 +65,7 @@ class TokensEmspClient(
                         "token_uid" to tokenUid,
                         type?.let { "type" to type.toString() }).toMap()
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             ).parseBody()
 
@@ -88,7 +88,7 @@ class TokensEmspClient(
                         "token_uid" to tokenUid,
                         type?.let { "type" to type.toString() }).toMap()
                 )
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
             ).parseBody()
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionDetailsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionDetailsClient.kt
@@ -20,21 +20,27 @@ class VersionDetailsClient(
 ) : VersionDetailsInterface {
 
     override suspend fun getVersionDetails(): OcpiResponseBody<VersionDetails> =
-        transportClientBuilder
-            .build(
-                baseUrl = platformRepository
-                    .getVersion(platformUrl = serverVersionsEndpointUrl)
-                    ?.url
-                    ?: throw OcpiToolkitUnknownEndpointException("version details")
-            )
-            .send(
+        with(
+            transportClientBuilder
+                .build(
+                    baseUrl = platformRepository
+                        .getVersion(platformUrl = serverVersionsEndpointUrl)
+                        ?.url
+                        ?: throw OcpiToolkitUnknownEndpointException("version details")
+                )
+        ) {
+            send(
                 HttpRequest(method = HttpMethod.GET)
-                    .withRequiredHeaders()
+                    .withRequiredHeaders(
+                        requestId = generateRequestId(),
+                        correlationId = generateCorrelationId()
+                    )
                     .authenticate(
                         platformRepository = platformRepository,
                         baseUrl = serverVersionsEndpointUrl,
                         allowTokenAOrTokenB = true
                     )
             )
-            .parseBody()
+                .parseBody()
+        }
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionDetailsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionDetailsClient.kt
@@ -29,7 +29,7 @@ class VersionDetailsClient(
             )
             .send(
                 HttpRequest(method = HttpMethod.GET)
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(
                         platformRepository = platformRepository,
                         baseUrl = serverVersionsEndpointUrl,

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsClient.kt
@@ -3,7 +3,7 @@ package com.izivia.ocpi.toolkit.modules.versions
 import com.izivia.ocpi.toolkit.common.OcpiResponseBody
 import com.izivia.ocpi.toolkit.common.authenticate
 import com.izivia.ocpi.toolkit.common.parseBody
-import com.izivia.ocpi.toolkit.common.withDebugHeaders
+import com.izivia.ocpi.toolkit.common.withRequiredHeaders
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformRepository
 import com.izivia.ocpi.toolkit.modules.versions.domain.Version
 import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
@@ -27,7 +27,7 @@ class VersionsClient(
             .build(baseUrl = serverVersionsEndpointUrl)
             .send(
                 HttpRequest(method = HttpMethod.GET)
-                    .withDebugHeaders()
+                    .withRequiredHeaders()
                     .authenticate(
                         platformRepository = platformRepository,
                         baseUrl = serverVersionsEndpointUrl,

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsClient.kt
@@ -23,16 +23,22 @@ class VersionsClient(
 ) : VersionsInterface {
 
     override suspend fun getVersions(): OcpiResponseBody<List<Version>> =
-        transportClientBuilder
-            .build(baseUrl = serverVersionsEndpointUrl)
-            .send(
+        with(
+            transportClientBuilder
+                .build(baseUrl = serverVersionsEndpointUrl)
+        ) {
+            send(
                 HttpRequest(method = HttpMethod.GET)
-                    .withRequiredHeaders()
+                    .withRequiredHeaders(
+                        requestId = generateRequestId(),
+                        correlationId = generateCorrelationId()
+                    )
                     .authenticate(
                         platformRepository = platformRepository,
                         baseUrl = serverVersionsEndpointUrl,
                         allowTokenAOrTokenB = true
                     )
             )
-            .parseBody()
+                .parseBody()
+        }
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Http4kTransportClient.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Http4kTransportClient.kt
@@ -8,6 +8,10 @@ import org.http4k.client.JettyClient
 import org.http4k.core.*
 import org.http4k.filter.ClientFilters
 
+// These values are used for testing, it's not useful for your transport implementation
+var requestCounter = 1
+var correlationCounter = 1
+
 class Http4kTransportClient(
     val client: HttpHandler
 ) : TransportClient {
@@ -22,6 +26,12 @@ class Http4kTransportClient(
             )
         }
     }
+
+    override suspend fun generateCorrelationId(): String = "corr-id-$correlationCounter"
+        .also { correlationCounter += 1 }
+
+    override suspend fun generateRequestId(): String = "req-id-$requestCounter"
+        .also { requestCounter += 1 }
 
     companion object {
         operator fun invoke(baseUrl: String) =

--- a/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/TransportClient.kt
+++ b/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/TransportClient.kt
@@ -2,6 +2,7 @@ package com.izivia.ocpi.toolkit.transport
 
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 import com.izivia.ocpi.toolkit.transport.domain.HttpResponse
+import java.util.*
 
 interface TransportClient {
     /**
@@ -10,6 +11,18 @@ interface TransportClient {
      * @return the response sent by the server
      */
     fun send(request: HttpRequest): HttpResponse
+
+    /**
+     * Override this method if you want to use your own login to generate de X_Correlation_ID header value.
+     * @return String X_Correlation_ID header value
+     */
+    suspend fun generateCorrelationId(): String = UUID.randomUUID().toString()
+
+    /**
+     * Override this method if you want to use your own login to generate de X_Request_ID header value
+     * @return String X_Request_ID header value
+     */
+    suspend fun generateRequestId(): String = UUID.randomUUID().toString()
 }
 
 interface TransportClientBuilder {


### PR DESCRIPTION
## Change notes

**Only for ocpi 2.2.1**

- `Content-Type: application/json` header is now added on requests if the body is not null
- `Content-Type: application/json` header is now added on all responses
- Headers are not case sensitive anymore. It means that `X-Request-ID` and `X-Correlation-ID` are properly propagated in responses even if the case does not match. Note: `Authorization` header was working because it also accepted `authorization`
- It is now possible to define how `X-Request-ID` and `X-Correlation-ID` are generated. You have to override methods in your `TransportClient` implementation. By default, the behaviour stays the same, it generates a random `UUID`.

**Migration guide**

If you manually added Content-Type header & normalized headers in your Transport implementation, you can remove it.

Otherwise, you do not need to update anything. All the changes are included in the lib.

**Notes**

For versions 2.1.1 and 2.1.1 Gireve, two issues have been open:
- https://github.com/IZIVIA/ocpi-toolkit/issues/12
- https://github.com/IZIVIA/ocpi-toolkit/issues/13