### PR TITLE
fix(ocpi-2.2.1): Fixed usage of tokens & review PlatformRepository

### DIFF
--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -132,7 +132,7 @@ fun HttpRequest.parseAuthorizationHeader() = (headers["Authorization"] ?: header
  * @throws OcpiClientNotEnoughInformationException if the token is missing
  * @throws HttpException if the authorization header is missing
  */
-fun PlatformRepository.tokenFilter(httpRequest: HttpRequest) {
+fun PlatformRepository.checkToken(httpRequest: HttpRequest) {
     val token = httpRequest.parseAuthorizationHeader()
 
     if (!platformExistsWithTokenA(token) &&

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -143,9 +143,9 @@ fun PlatformRepository.checkToken(httpRequest: HttpRequest) {
     }
 }
 
-fun TransportClientBuilder.buildFor(module: ModuleID, platform: String, platformRepository: PlatformRepository) =
+fun TransportClientBuilder.buildFor(module: ModuleID, platformUrl: String, platformRepository: PlatformRepository) =
     platformRepository
-        .getEndpoints(platformUrl = platform)
+        .getEndpoints(platformUrl = platformUrl)
         .find { it.identifier == module }
         ?.let { build(baseUrl = it.url) }
         ?: throw OcpiToolkitUnknownEndpointException(endpointName = module.name)

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
@@ -24,7 +24,7 @@ class LocationsCpoClient(
     private fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.locations,
-            platform = serverVersionsEndpointUrl,
+            platformUrl = serverVersionsEndpointUrl,
             platformRepository = platformRepository
         )
 

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoServer.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoServer.kt
@@ -1,7 +1,7 @@
 package com.izivia.ocpi.toolkit.modules.locations
 
 import com.izivia.ocpi.toolkit.common.httpResponse
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformRepository
 import com.izivia.ocpi.toolkit.transport.TransportServer
 import com.izivia.ocpi.toolkit.transport.domain.FixedPathSegment
@@ -28,7 +28,7 @@ class LocationsCpoServer(
                 method = HttpMethod.GET,
                 path = basePath,
                 queryParams = listOf("date_from", "date_to", "offset", "limit"),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     val dateFrom = req.queryParams["date_from"]
@@ -47,7 +47,7 @@ class LocationsCpoServer(
             transportServer.handle(
                 method = HttpMethod.GET,
                 path = basePath + VariablePathSegment("locationId"),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -63,7 +63,7 @@ class LocationsCpoServer(
                     VariablePathSegment("locationId"),
                     VariablePathSegment("evseUid")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -81,7 +81,7 @@ class LocationsCpoServer(
                     VariablePathSegment("evseUid"),
                     VariablePathSegment("connectorId")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
@@ -27,7 +27,7 @@ class LocationsEmspClient(
     private fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.locations,
-            platform = serverVersionsEndpointUrl,
+            platformUrl = serverVersionsEndpointUrl,
             platformRepository = platformRepository
         )
 

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspServer.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspServer.kt
@@ -2,7 +2,7 @@ package com.izivia.ocpi.toolkit.modules.locations
 
 import com.izivia.ocpi.toolkit.common.httpResponse
 import com.izivia.ocpi.toolkit.common.mapper
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformRepository
 import com.izivia.ocpi.toolkit.modules.locations.domain.*
 import com.izivia.ocpi.toolkit.transport.TransportServer
@@ -32,7 +32,7 @@ class LocationsEmspServer(
                     VariablePathSegment("partyId"),
                     VariablePathSegment("locationId")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -52,7 +52,7 @@ class LocationsEmspServer(
                     VariablePathSegment("locationId"),
                     VariablePathSegment("evseUid")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -74,7 +74,7 @@ class LocationsEmspServer(
                     VariablePathSegment("evseUid"),
                     VariablePathSegment("connectorId")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -95,7 +95,7 @@ class LocationsEmspServer(
                     VariablePathSegment("partyId"),
                     VariablePathSegment("locationId")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -116,7 +116,7 @@ class LocationsEmspServer(
                     VariablePathSegment("locationId"),
                     VariablePathSegment("evseUid")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -139,7 +139,7 @@ class LocationsEmspServer(
                     VariablePathSegment("evseUid"),
                     VariablePathSegment("connectorId")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -161,7 +161,7 @@ class LocationsEmspServer(
                     VariablePathSegment("partyId"),
                     VariablePathSegment("locationId")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -182,7 +182,7 @@ class LocationsEmspServer(
                     VariablePathSegment("locationId"),
                     VariablePathSegment("evseUid")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -205,7 +205,7 @@ class LocationsEmspServer(
                     VariablePathSegment("evseUid"),
                     VariablePathSegment("connectorId")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
@@ -22,7 +22,7 @@ class TokensCpoClient(
     private fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.tokens,
-            platform = serverVersionsEndpointUrl,
+            platformUrl = serverVersionsEndpointUrl,
             platformRepository = platformRepository
         )
 

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoServer.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoServer.kt
@@ -2,7 +2,7 @@ package com.izivia.ocpi.toolkit.modules.tokens
 
 import com.izivia.ocpi.toolkit.common.httpResponse
 import com.izivia.ocpi.toolkit.common.mapper
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformRepository
 import com.izivia.ocpi.toolkit.modules.tokens.domain.Token
 import com.izivia.ocpi.toolkit.modules.tokens.domain.TokenPartial
@@ -29,7 +29,7 @@ class TokensCpoServer(
                     VariablePathSegment("partyId"),
                     VariablePathSegment("tokenUid")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -48,7 +48,7 @@ class TokensCpoServer(
                     VariablePathSegment("partyId"),
                     VariablePathSegment("tokenUid")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -68,7 +68,7 @@ class TokensCpoServer(
                     VariablePathSegment("partyId"),
                     VariablePathSegment("tokenUid")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
@@ -19,7 +19,7 @@ class TokensEmspClient(
     private fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.tokens,
-            platform = serverVersionsEndpointUrl,
+            platformUrl = serverVersionsEndpointUrl,
             platformRepository = platformRepository
         )
 

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspServer.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspServer.kt
@@ -2,7 +2,7 @@ package com.izivia.ocpi.toolkit.modules.tokens
 
 import com.izivia.ocpi.toolkit.common.httpResponse
 import com.izivia.ocpi.toolkit.common.mapper
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformRepository
 import com.izivia.ocpi.toolkit.modules.tokens.domain.LocationReferences
 import com.izivia.ocpi.toolkit.modules.tokens.domain.TokenType
@@ -34,7 +34,7 @@ class TokensEmspServer(
                     "ocpi-to-country-code",
                     "ocpi-to-party-id"
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     val dateFrom = req.queryParams["date_from"]
@@ -58,7 +58,7 @@ class TokensEmspServer(
                     VariablePathSegment("tokenUid")
                 ),
                 queryParams = listOf("type"),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -76,7 +76,7 @@ class TokensEmspServer(
                     FixedPathSegment("authorize")
                 ),
                 queryParams = listOf("type"),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionDetailsServer.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionDetailsServer.kt
@@ -1,7 +1,7 @@
 package com.izivia.ocpi.toolkit.modules.versions
 
 import com.izivia.ocpi.toolkit.common.httpResponse
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformRepository
 import com.izivia.ocpi.toolkit.modules.versions.validation.VersionDetailsValidationService
 import com.izivia.ocpi.toolkit.transport.TransportServer
@@ -23,7 +23,7 @@ class VersionDetailsServer(
                 path = basePath + listOf(
                     VariablePathSegment("versionNumber")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     validationService.getVersionDetails(

--- a/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsServer.kt
+++ b/ocpi-toolkit-2.1.1-gireve/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsServer.kt
@@ -1,7 +1,7 @@
 package com.izivia.ocpi.toolkit.modules.versions
 
 import com.izivia.ocpi.toolkit.common.httpResponse
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformRepository
 import com.izivia.ocpi.toolkit.modules.versions.validation.VersionsValidationService
 import com.izivia.ocpi.toolkit.transport.TransportServer
@@ -23,7 +23,7 @@ class VersionsServer(
             transportServer.handle(
                 method = HttpMethod.GET,
                 path = basePath,
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     validationService.getVersions()

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -132,7 +132,7 @@ fun HttpRequest.parseAuthorizationHeader() = (headers["Authorization"] ?: header
  * @throws OcpiClientNotEnoughInformationException if the token is missing
  * @throws HttpException if the authorization header is missing
  */
-fun PlatformRepository.tokenFilter(httpRequest: HttpRequest) {
+fun PlatformRepository.checkToken(httpRequest: HttpRequest) {
     val token = httpRequest.parseAuthorizationHeader()
 
     if (!platformExistsWithTokenA(token) &&

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -143,9 +143,9 @@ fun PlatformRepository.checkToken(httpRequest: HttpRequest) {
     }
 }
 
-fun TransportClientBuilder.buildFor(module: ModuleID, platform: String, platformRepository: PlatformRepository) =
+fun TransportClientBuilder.buildFor(module: ModuleID, platformUrl: String, platformRepository: PlatformRepository) =
     platformRepository
-        .getEndpoints(platformUrl = platform)
+        .getEndpoints(platformUrl = platformUrl)
         .find { it.identifier == module }
         ?.let { build(baseUrl = it.url) }
         ?: throw OcpiToolkitUnknownEndpointException(endpointName = module.name)

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
@@ -24,7 +24,7 @@ class LocationsCpoClient(
     private fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.locations,
-            platform = serverVersionsEndpointUrl,
+            platformUrl = serverVersionsEndpointUrl,
             platformRepository = platformRepository
         )
 

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoServer.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoServer.kt
@@ -1,7 +1,7 @@
 package com.izivia.ocpi.toolkit.modules.locations
 
 import com.izivia.ocpi.toolkit.common.httpResponse
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformRepository
 import com.izivia.ocpi.toolkit.transport.TransportServer
 import com.izivia.ocpi.toolkit.transport.domain.FixedPathSegment
@@ -28,7 +28,7 @@ class LocationsCpoServer(
                 method = HttpMethod.GET,
                 path = basePath,
                 queryParams = listOf("date_from", "date_to", "offset", "limit"),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     val dateFrom = req.queryParams["date_from"]
@@ -47,7 +47,7 @@ class LocationsCpoServer(
             transportServer.handle(
                 method = HttpMethod.GET,
                 path = basePath + VariablePathSegment("locationId"),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -63,7 +63,7 @@ class LocationsCpoServer(
                     VariablePathSegment("locationId"),
                     VariablePathSegment("evseUid")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -81,7 +81,7 @@ class LocationsCpoServer(
                     VariablePathSegment("evseUid"),
                     VariablePathSegment("connectorId")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
@@ -27,7 +27,7 @@ class LocationsEmspClient(
     private fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.locations,
-            platform = serverVersionsEndpointUrl,
+            platformUrl = serverVersionsEndpointUrl,
             platformRepository = platformRepository
         )
 

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspServer.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspServer.kt
@@ -2,7 +2,7 @@ package com.izivia.ocpi.toolkit.modules.locations
 
 import com.izivia.ocpi.toolkit.common.httpResponse
 import com.izivia.ocpi.toolkit.common.mapper
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformRepository
 import com.izivia.ocpi.toolkit.modules.locations.domain.*
 import com.izivia.ocpi.toolkit.transport.TransportServer
@@ -32,7 +32,7 @@ class LocationsEmspServer(
                     VariablePathSegment("partyId"),
                     VariablePathSegment("locationId")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -52,7 +52,7 @@ class LocationsEmspServer(
                     VariablePathSegment("locationId"),
                     VariablePathSegment("evseUid")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -74,7 +74,7 @@ class LocationsEmspServer(
                     VariablePathSegment("evseUid"),
                     VariablePathSegment("connectorId")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -95,7 +95,7 @@ class LocationsEmspServer(
                     VariablePathSegment("partyId"),
                     VariablePathSegment("locationId")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -116,7 +116,7 @@ class LocationsEmspServer(
                     VariablePathSegment("locationId"),
                     VariablePathSegment("evseUid")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -139,7 +139,7 @@ class LocationsEmspServer(
                     VariablePathSegment("evseUid"),
                     VariablePathSegment("connectorId")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -161,7 +161,7 @@ class LocationsEmspServer(
                     VariablePathSegment("partyId"),
                     VariablePathSegment("locationId")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -182,7 +182,7 @@ class LocationsEmspServer(
                     VariablePathSegment("locationId"),
                     VariablePathSegment("evseUid")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -205,7 +205,7 @@ class LocationsEmspServer(
                     VariablePathSegment("evseUid"),
                     VariablePathSegment("connectorId")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
@@ -22,7 +22,7 @@ class TokensCpoClient(
     private fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.tokens,
-            platform = serverVersionsEndpointUrl,
+            platformUrl = serverVersionsEndpointUrl,
             platformRepository = platformRepository
         )
 

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoServer.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoServer.kt
@@ -2,7 +2,7 @@ package com.izivia.ocpi.toolkit.modules.tokens
 
 import com.izivia.ocpi.toolkit.common.httpResponse
 import com.izivia.ocpi.toolkit.common.mapper
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformRepository
 import com.izivia.ocpi.toolkit.modules.tokens.domain.Token
 import com.izivia.ocpi.toolkit.modules.tokens.domain.TokenPartial
@@ -29,7 +29,7 @@ class TokensCpoServer(
                     VariablePathSegment("partyId"),
                     VariablePathSegment("tokenUid")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -48,7 +48,7 @@ class TokensCpoServer(
                     VariablePathSegment("partyId"),
                     VariablePathSegment("tokenUid")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service
@@ -68,7 +68,7 @@ class TokensCpoServer(
                     VariablePathSegment("partyId"),
                     VariablePathSegment("tokenUid")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
@@ -19,7 +19,7 @@ class TokensEmspClient(
     private fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.tokens,
-            platform = serverVersionsEndpointUrl,
+            platformUrl = serverVersionsEndpointUrl,
             platformRepository = platformRepository
         )
 

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspServer.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspServer.kt
@@ -2,7 +2,7 @@ package com.izivia.ocpi.toolkit.modules.tokens
 
 import com.izivia.ocpi.toolkit.common.httpResponse
 import com.izivia.ocpi.toolkit.common.mapper
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformRepository
 import com.izivia.ocpi.toolkit.modules.tokens.domain.LocationReferences
 import com.izivia.ocpi.toolkit.modules.tokens.domain.TokenType
@@ -27,7 +27,7 @@ class TokensEmspServer(
                 method = HttpMethod.GET,
                 path = basePath,
                 queryParams = listOf("date_from", "date_to", "offset", "limit"),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     val dateFrom = req.queryParams["date_from"]
@@ -50,7 +50,7 @@ class TokensEmspServer(
                     FixedPathSegment("authorize")
                 ),
                 queryParams = listOf("type"),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     service

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionDetailsServer.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionDetailsServer.kt
@@ -1,7 +1,7 @@
 package com.izivia.ocpi.toolkit.modules.versions
 
 import com.izivia.ocpi.toolkit.common.httpResponse
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformRepository
 import com.izivia.ocpi.toolkit.modules.versions.validation.VersionDetailsValidationService
 import com.izivia.ocpi.toolkit.transport.TransportServer
@@ -23,7 +23,7 @@ class VersionDetailsServer(
                 path = basePath + listOf(
                     VariablePathSegment("versionNumber")
                 ),
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     validationService.getVersionDetails(

--- a/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsServer.kt
+++ b/ocpi-toolkit-2.1.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsServer.kt
@@ -1,7 +1,7 @@
 package com.izivia.ocpi.toolkit.modules.versions
 
 import com.izivia.ocpi.toolkit.common.httpResponse
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformRepository
 import com.izivia.ocpi.toolkit.modules.versions.validation.VersionsValidationService
 import com.izivia.ocpi.toolkit.transport.TransportServer
@@ -23,7 +23,7 @@ class VersionsServer(
             transportServer.handle(
                 method = HttpMethod.GET,
                 path = basePath,
-                filters = listOf(platformRepository::tokenFilter)
+                filters = listOf(platformRepository::checkToken)
             ) { req ->
                 req.httpResponse {
                     validationService.getVersions()

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -258,7 +258,7 @@ fun HttpRequest.parseAuthorizationHeader() = getHeader(Header.AUTHORIZATION)
  * @throws HttpException if the authorization header is missing
  *
  */
-suspend fun PlatformRepository.tokenFilter(
+suspend fun PlatformRepository.checkToken(
     httpRequest: HttpRequest
 ) {
     val token = httpRequest.parseAuthorizationHeader()

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -285,11 +285,11 @@ suspend fun PlatformRepository.checkToken(
 
 suspend fun TransportClientBuilder.buildFor(
     module: ModuleID,
-    platform: String,
+    platformUrl: String,
     platformRepository: PlatformRepository
 ): TransportClient =
     platformRepository
-        .getEndpoints(platformUrl = platform)
+        .getEndpoints(platformUrl = platformUrl)
         .find { it.identifier == module }
         ?.let { build(baseUrl = it.url) }
         ?: throw OcpiToolkitUnknownEndpointException(endpointName = module.name)

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/CredentialsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/CredentialsClient.kt
@@ -14,7 +14,7 @@ class CredentialsClient(
     private val transportClient: TransportClient
 ) : CredentialsInterface {
 
-    override suspend fun get(tokenC: String): OcpiResponseBody<Credentials> =
+    override suspend fun get(token: String): OcpiResponseBody<Credentials> =
         transportClient
             .send(
                 HttpRequest(method = HttpMethod.GET)
@@ -22,7 +22,7 @@ class CredentialsClient(
                         requestId = transportClient.generateRequestId(),
                         correlationId = transportClient.generateCorrelationId()
                     )
-                    .authenticate(token = tokenC)
+                    .authenticate(token = token)
             )
             .parseBody()
 
@@ -46,7 +46,7 @@ class CredentialsClient(
             .parseBody()
 
     override suspend fun put(
-        tokenC: String,
+        token: String,
         credentials: Credentials,
         debugHeaders: Map<String, String>
     ): OcpiResponseBody<Credentials> =
@@ -60,11 +60,11 @@ class CredentialsClient(
                         requestId = transportClient.generateRequestId(),
                         correlationId = transportClient.generateCorrelationId()
                     )
-                    .authenticate(token = tokenC)
+                    .authenticate(token = token)
             )
             .parseBody()
 
-    override suspend fun delete(tokenC: String): OcpiResponseBody<Credentials?> =
+    override suspend fun delete(token: String): OcpiResponseBody<Credentials?> =
         transportClient
             .send(
                 HttpRequest(method = HttpMethod.DELETE)
@@ -72,7 +72,7 @@ class CredentialsClient(
                         requestId = transportClient.generateRequestId(),
                         correlationId = transportClient.generateCorrelationId()
                     )
-                    .authenticate(token = tokenC)
+                    .authenticate(token = token)
             )
             .parseBody()
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/CredentialsInterface.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/CredentialsInterface.kt
@@ -14,7 +14,7 @@ interface CredentialsInterface {
      * contains the credentials object to access the server’s platform. This credentials object also contains extra
      * information about the server such as its business details.
      */
-    suspend fun get(tokenC: String): OcpiResponseBody<Credentials>
+    suspend fun get(token: String): OcpiResponseBody<Credentials>
 
     /**
      * Provides the server with credentials to access the client's system. This credentials object also contains extra
@@ -28,7 +28,11 @@ interface CredentialsInterface {
      * This method MUST return a HTTP status code 405: method not allowed if the client has already been registered
      * before.
      */
-    suspend fun post(tokenA: String, credentials: Credentials, debugHeaders: Map<String, String>): OcpiResponseBody<Credentials>
+    suspend fun post(
+        tokenA: String,
+        credentials: Credentials,
+        debugHeaders: Map<String, String>
+    ): OcpiResponseBody<Credentials>
 
     /**
      * Provides the server with updated credentials to access the client’s system. This credentials object also contains
@@ -43,7 +47,11 @@ interface CredentialsInterface {
      *
      * This method MUST return a HTTP status code 405: method not allowed if the client has not been registered yet.
      */
-    suspend fun put(tokenC: String, credentials: Credentials, debugHeaders: Map<String, String>): OcpiResponseBody<Credentials>
+    suspend fun put(
+        token: String,
+        credentials: Credentials,
+        debugHeaders: Map<String, String>
+    ): OcpiResponseBody<Credentials>
 
     /**
      * Informs the server that its credentials to access the client’s system are now invalid and can no longer be used.
@@ -51,5 +59,5 @@ interface CredentialsInterface {
      *
      * This method MUST return a HTTP status code 405: method not allowed if the client has not been registered before.
      */
-    suspend fun delete(tokenC: String): OcpiResponseBody<Credentials?>
+    suspend fun delete(token: String): OcpiResponseBody<Credentials?>
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/CredentialsServer.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/CredentialsServer.kt
@@ -4,7 +4,6 @@ import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.modules.credentials.domain.Credentials
 import com.izivia.ocpi.toolkit.modules.credentials.services.CredentialsServerService
 import com.izivia.ocpi.toolkit.transport.TransportServer
-import com.izivia.ocpi.toolkit.transport.domain.FixedPathSegment
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 
 class CredentialsServer(
@@ -19,7 +18,7 @@ class CredentialsServer(
         ) { req ->
             req.httpResponse {
                 service.get(
-                    tokenC = req.parseAuthorizationHeader()
+                    token = req.parseAuthorizationHeader()
                 )
             }
         }
@@ -45,7 +44,7 @@ class CredentialsServer(
         ) { req ->
             req.httpResponse {
                 service.put(
-                    tokenC = req.parseAuthorizationHeader(),
+                    token = req.parseAuthorizationHeader(),
                     credentials = mapper.readValue(req.body!!, Credentials::class.java),
                     debugHeaders = req.getDebugHeaders()
                 )
@@ -59,7 +58,7 @@ class CredentialsServer(
         ) { req ->
             req.httpResponse {
                 service.delete(
-                    tokenC = req.parseAuthorizationHeader()
+                    token = req.parseAuthorizationHeader()
                 )
             }
         }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PlatformRepository.kt
@@ -4,28 +4,164 @@ import com.izivia.ocpi.toolkit.modules.versions.domain.Endpoint
 import com.izivia.ocpi.toolkit.modules.versions.domain.Version
 
 /**
- * - CREDENTIALS_TOKEN_A: used by the client to communicate with the server (when initiating registration).
- * - CREDENTIALS_TOKEN_B: used by the server to communicate with the client (during registration).
- * - CREDENTIALS_TOKEN_C: used by the client to communicate with the server (once registered).
+ * **Note about tokens:**
+ * The Credentials Token A is used by the sender to communicate with the receiver (only when initiating registration).
+ * After registration, it is invalidated.
+ *
+ * Then, there are two tokens, and the token to use is specified by the registration process.
+ * - When you are the receiver during registration:
+ *   - OCPI Token B is the client token, the one you have to use to send requests
+ *   - OCPI Token C is the server token, the one you have to use to check if requests are properly authenticated
+ * - When you are the sender during registration:
+ *   - OCPI Token B is the server token, the one you have to use to check if requests are properly authenticated
+ *   - OCPI Token C is the client token, the one you have to use to send requests
+ *
+ * This is why we do not use OCPI's token B and token C naming. According to who you are in the registration process,
+ * you have to use a different token. Using "Client Token" and "Server Token" simplifies that process of picking the
+ * right token for the right operation.
  */
 interface PlatformRepository {
+
+    /**
+     * When calling a partner, the http client has to be authenticated. This method is called to retrieve the
+     * token A for a given partner identified by its /versions url.
+     *
+     * The token A is only used during registration process.
+     *
+     * @param platformUrl the partner, identified by its /versions url
+     * @return the token A, if found, null otherwise
+     */
     suspend fun getCredentialsTokenA(platformUrl: String): String?
-    suspend fun getCredentialsTokenB(platformUrl: String): String?
-    suspend fun getCredentialsTokenC(platformUrl: String): String?
-    suspend fun platformExistsWithTokenA(token: String): Boolean
-    suspend fun platformExistsWithTokenB(token: String): Boolean
-    suspend fun getPlatformUrlByTokenC(token: String): String?
+
+    /**
+     * When calling a partner, the http client has to be authenticated. This method is called to retrieve the
+     * client token for a given partner identified by its /versions url.
+     *
+     * @param platformUrl the partner, identified by its /versions url
+     * @return the client token, if found, null otherwise
+     */
+    suspend fun getCredentialsClientToken(platformUrl: String): String?
+
+    /**
+     * A partner has to use its server token to communicate with us. On first registration, the token used is the token
+     * A. This method is called to check if the token A of a partner is valid.
+     *
+     * @param credentialsTokenA the token of a partner
+     * @return true if the token is valid (exists), false otherwise
+     */
+    suspend fun isCredentialsTokenAValid(credentialsTokenA: String): Boolean
+
+    /**
+     * A partner has to use its server token to communicate with us. This method is called to check if the token of a
+     * partner is valid.
+     *
+     * @param credentialsServerToken the token of a partner
+     * @return true if the token is valid (exists), false otherwise
+     */
+    suspend fun isCredentialsServerTokenValid(credentialsServerToken: String): Boolean
+
+    /**
+     * Used to find a platform url by its server token. Basically used to retrieve all the partner information
+     * from the token in a request.
+     *
+     * @param credentialsServerToken the server token, the one partners use to communicate
+     * @return the platform url
+     */
+    suspend fun getPlatformUrlByCredentialsServerToken(credentialsServerToken: String): String?
+
+    /**
+     * Used to get available endpoints for a given partner identified by its url (platformUrl)
+     *
+     * @param platformUrl the partner, identified by its /versions url
+     * @return the list of available endpoints for the given partner
+     */
     suspend fun getEndpoints(platformUrl: String): List<Endpoint>
+
+    /**
+     * Used to get used version for a given partner identified by its url (platformUrl)
+     *
+     * @param platformUrl the partner, identified by its /versions url
+     * @return the currently used version for the given partner or null
+     */
     suspend fun getVersion(platformUrl: String): Version?
+
+    /**
+     * This is the first function to be called on registration. So that later on we can use platform url as an
+     * identifier for a given partner.
+     *
+     * It searches for a platform with the given token A and saves the corresponding platformUrl
+     *
+     * @param tokenA
+     * @param platformUrl the partner, identified by its /versions url
+     * @return the platformUrl if a platform was found for given token A and the update was a success, null otherwise
+     */
     suspend fun savePlatformUrlForTokenA(tokenA: String, platformUrl: String): String?
+
+    /**
+     * Used to save available version for a given partner identified by its url (platformUrl)
+     *
+     * @param platformUrl the partner, identified by its /versions url
+     * @param version Version
+     * @return the updated version
+     */
     suspend fun saveVersion(platformUrl: String, version: Version): Version
+
+    /**
+     * Used to save endpoints for a given partner identified by its url (platformUrl)
+     *
+     * @param platformUrl the partner, identified by its /versions url
+     * @param endpoints List<Endpoint>
+     * @return List<Endpoint> the updated list of endpoints
+     */
     suspend fun saveEndpoints(platformUrl: String, endpoints: List<Endpoint>): List<Endpoint>
-    suspend fun saveCredentialsTokenA(platformUrl: String, credentialsTokenA: String): String
-    suspend fun saveCredentialsTokenB(platformUrl: String, credentialsTokenB: String): String
-    suspend fun saveCredentialsTokenC(platformUrl: String, credentialsTokenC: String): String
-    suspend fun removeCredentialsTokenA(platformUrl: String)
-    suspend fun removeCredentialsTokenB(platformUrl: String)
-    suspend fun removeCredentialsTokenC(platformUrl: String)
-    suspend fun removeVersion(platformUrl: String)
-    suspend fun removeEndpoints(platformUrl: String)
+
+    /**
+     * Called to save the client token for a given partner identified by its url (platformUrl).
+     *
+     * This token is the one that will be used to communicate with the partner.
+     * For context in OCPI, on registration, this token is:
+     * - if you are the receiver: token B
+     * - if you are the sender: token C
+     *
+     * @param platformUrl the partner, identified by its /versions url
+     * @param credentialsClientToken String
+     * @return the credentialsClientToken
+     */
+    suspend fun saveCredentialsClientToken(platformUrl: String, credentialsClientToken: String): String
+
+    /**
+     * Called to save the server token for a given partner identified by its url (platformUrl).
+     *
+     * This token is the one that the partner will use to communicate. So it is this token that has to be used to check
+     * if requests are properly authenticated.
+     *
+     * For context in OCPI, on registration, this token is:
+     * - if you are the receiver: token C
+     * - if you are the sender: token B
+     *
+     * @param platformUrl the partner, identified by its /versions url
+     * @param credentialsServerToken String
+     * @return the credentialsServerToken
+     */
+    suspend fun saveCredentialsServerToken(platformUrl: String, credentialsServerToken: String): String
+
+    /**
+     * Called once registration is done for a given partner identified by its url (platformUrl).
+     *
+     * The token A has to be invalidated.
+     *
+     * @param platformUrl the partner, identified by its /versions url
+     * @return true if it was a success, false otherwise
+     */
+    suspend fun invalidateCredentialsTokenA(platformUrl: String): Boolean
+
+    /**
+     * Called on unregistration for a given partner identified by its url (platformUrl).
+     *
+     * It has to at least invalidate all the tokens. So that future requests with those token fail.
+     *
+     * @param platformUrl the partner, identified by its /versions url
+     * @return true if it was a success, false otherwise
+     */
+    suspend fun unregisterPlatform(platformUrl: String): Boolean
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
@@ -42,7 +42,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
         )
             .parseBody()
     }
@@ -62,7 +62,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
         )
             .parseBody()
     }
@@ -83,7 +83,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
         )
             .parseBody()
     }
@@ -104,7 +104,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
         )
             .parseBody()
     }
@@ -126,7 +126,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
         )
             .parseBody()
     }
@@ -149,7 +149,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
         )
             .parseBody()
     }
@@ -170,7 +170,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
         )
             .parseBody()
     }
@@ -192,7 +192,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
         )
             .parseBody()
     }
@@ -215,7 +215,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
         )
             .parseBody()
     }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
@@ -24,7 +24,7 @@ class LocationsCpoClient(
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.locations,
-            platform = serverVersionsEndpointUrl,
+            platformUrl = serverVersionsEndpointUrl,
             platformRepository = platformRepository
         )
 

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
@@ -51,7 +51,7 @@ class LocationsEmspClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
         )
             .parsePaginatedBody(offset)
     }
@@ -66,7 +66,7 @@ class LocationsEmspClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
         )
             .parseBody()
     }
@@ -82,7 +82,7 @@ class LocationsEmspClient(
                         requestId = generateRequestId(),
                         correlationId = generateCorrelationId()
                     )
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                    .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
             )
                 .parseBody()
         }
@@ -101,7 +101,7 @@ class LocationsEmspClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
         )
             .parseBody()
     }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
@@ -27,7 +27,7 @@ class LocationsEmspClient(
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.locations,
-            platform = serverVersionsEndpointUrl,
+            platformUrl = serverVersionsEndpointUrl,
             platformRepository = platformRepository
         )
 

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsCpoClient.kt
@@ -41,7 +41,7 @@ class SessionsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                    .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
             )
                 .parseBody()
         }
@@ -62,7 +62,7 @@ class SessionsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                    .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
             )
                 .parseBody()
         }
@@ -83,7 +83,7 @@ class SessionsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                    .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
             )
                 .parseBody()
         }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsCpoClient.kt
@@ -23,7 +23,7 @@ class SessionsCpoClient(
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.sessions,
-            platform = serverVersionsEndpointUrl,
+            platformUrl = serverVersionsEndpointUrl,
             platformRepository = platformRepository
         )
 

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsEmspClient.kt
@@ -50,7 +50,7 @@ class SessionsEmspClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                    .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
             )
                 .parsePaginatedBody(offset)
         }
@@ -69,7 +69,7 @@ class SessionsEmspClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                    .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
             )
                 .parseBody()
         }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsEmspClient.kt
@@ -26,7 +26,7 @@ class SessionsEmspClient(
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.sessions,
-            platform = serverVersionsEndpointUrl,
+            platformUrl = serverVersionsEndpointUrl,
             platformRepository = platformRepository
         )
 

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
@@ -52,7 +52,7 @@ class TokensCpoClient(
                         requestId = generateRequestId(),
                         correlationId = generateCorrelationId()
                     )
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                    .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
             )
                 .parsePaginatedBody(offset)
         }
@@ -74,7 +74,7 @@ class TokensCpoClient(
                         requestId = generateRequestId(),
                         correlationId = generateCorrelationId()
                     )
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                    .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
             ).parseBody()
         }
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
@@ -27,7 +27,7 @@ class TokensCpoClient(
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.tokens,
-            platform = serverVersionsEndpointUrl,
+            platformUrl = serverVersionsEndpointUrl,
             platformRepository = platformRepository
         )
 

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
@@ -47,7 +47,7 @@ class TokensEmspClient(
                         requestId = generateRequestId(),
                         correlationId = generateCorrelationId()
                     )
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                    .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
             ).parseBody()
         }
 
@@ -74,7 +74,7 @@ class TokensEmspClient(
                         requestId = generateRequestId(),
                         correlationId = generateCorrelationId()
                     )
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                    .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
             ).parseBody()
         }
 
@@ -101,7 +101,7 @@ class TokensEmspClient(
                         requestId = generateRequestId(),
                         correlationId = generateCorrelationId()
                     )
-                    .authenticate(platformRepository = platformRepository, baseUrl = serverVersionsEndpointUrl)
+                    .authenticate(platformRepository = platformRepository, platformUrl = serverVersionsEndpointUrl)
             ).parseBody()
         }
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
@@ -26,7 +26,7 @@ class TokensEmspClient(
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.tokens,
-            platform = serverVersionsEndpointUrl,
+            platformUrl = serverVersionsEndpointUrl,
             platformRepository = platformRepository
         )
 

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionDetailsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionDetailsClient.kt
@@ -37,8 +37,8 @@ class VersionDetailsClient(
                     )
                     .authenticate(
                         platformRepository = platformRepository,
-                        baseUrl = serverVersionsEndpointUrl,
-                        allowTokenAOrTokenB = true
+                        platformUrl = serverVersionsEndpointUrl,
+                        allowTokenA = true
                     )
             )
                 .parseBody()

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsClient.kt
@@ -35,8 +35,8 @@ class VersionsClient(
                     )
                     .authenticate(
                         platformRepository = platformRepository,
-                        baseUrl = serverVersionsEndpointUrl,
-                        allowTokenAOrTokenB = true
+                        platformUrl = serverVersionsEndpointUrl,
+                        allowTokenA = true
                     )
             )
                 .parseBody()

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/DummyPlatformCacheRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/DummyPlatformCacheRepository.kt
@@ -1,10 +1,9 @@
 package com.izivia.ocpi.toolkit.samples.common
 
-class DummyPlatformCacheRepository(private val tokenC: String): PlatformCacheRepository() {
+class DummyPlatformCacheRepository : PlatformCacheRepository() {
+    override suspend fun isCredentialsServerTokenValid(credentialsServerToken: String): Boolean =
+        true
 
-    override suspend fun getPlatformUrlByTokenC(token: String): String? = super.getPlatformUrlByTokenC(token)
-        ?: (if (token == tokenC) "*" else null)
-
-    override suspend fun getCredentialsTokenC(platformUrl: String): String = super.getCredentialsTokenC(platformUrl)
-        ?: tokenC
+    override suspend fun getCredentialsClientToken(platformUrl: String): String =
+        "*"
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Platform.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Platform.kt
@@ -8,6 +8,6 @@ data class Platform(
     val version: Version? = null,
     val endpoints: List<Endpoint>? = null,
     val tokenA: String? = null,
-    val tokenB: String? = null,
-    val tokenC: String? = null
+    val clientToken: String? = null,
+    val serverToken: String? = null
 )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PlatformCacheRepository.kt
@@ -37,38 +37,32 @@ open class PlatformCacheRepository : PlatformRepository {
         .also { platforms[it.url!!] = it }
         .let { it.endpoints!! }
 
-    override suspend fun saveCredentialsTokenA(platformUrl: String, credentialsTokenA: String): String = platforms
-        .getOrDefault(platformUrl, Platform(platformUrl))
-        .copy(tokenA = credentialsTokenA)
-        .also { platforms[it.url!!] = it }
-        .let { it.tokenA!! }
+    override suspend fun saveCredentialsClientToken(platformUrl: String, credentialsClientToken: String): String =
+        platforms
+            .getOrDefault(platformUrl, Platform(platformUrl))
+            .copy(clientToken = credentialsClientToken)
+            .also { platforms[it.url!!] = it }
+            .let { it.clientToken!! }
 
-    override suspend fun saveCredentialsTokenB(platformUrl: String, credentialsTokenB: String): String = platforms
-        .getOrDefault(platformUrl, Platform(platformUrl))
-        .copy(tokenB = credentialsTokenB)
-        .also { platforms[it.url!!] = it }
-        .let { it.tokenB!! }
+    override suspend fun saveCredentialsServerToken(platformUrl: String, credentialsServerToken: String): String =
+        platforms
+            .getOrDefault(platformUrl, Platform(platformUrl))
+            .copy(serverToken = credentialsServerToken)
+            .also { platforms[it.url!!] = it }
+            .let { it.serverToken!! }
 
-    override suspend fun saveCredentialsTokenC(platformUrl: String, credentialsTokenC: String): String = platforms
-        .getOrDefault(platformUrl, Platform(platformUrl))
-        .copy(tokenC = credentialsTokenC)
-        .also { platforms[it.url!!] = it }
-        .let { it.tokenC!! }
-
-    override suspend fun getCredentialsTokenC(platformUrl: String): String? = platforms[platformUrl]?.tokenC
-
-    override suspend fun getCredentialsTokenB(platformUrl: String): String? = platforms[platformUrl]?.tokenB
+    override suspend fun getCredentialsClientToken(platformUrl: String): String? = platforms[platformUrl]?.clientToken
 
     override suspend fun getCredentialsTokenA(platformUrl: String): String? = platforms[platformUrl]?.tokenA
 
-    override suspend fun platformExistsWithTokenA(token: String): Boolean = platforms
-        .any { it.tokenA == token }
+    override suspend fun isCredentialsTokenAValid(credentialsTokenA: String): Boolean = platforms
+        .any { it.tokenA == credentialsTokenA }
 
-    override suspend fun platformExistsWithTokenB(token: String): Boolean = platforms
-        .any { it.tokenB == token }
+    override suspend fun isCredentialsServerTokenValid(credentialsServerToken: String): Boolean = platforms
+        .any { it.serverToken == credentialsServerToken }
 
-    override suspend fun getPlatformUrlByTokenC(token: String): String? = platforms
-        .firstOrNull { it.tokenC == token }?.url
+    override suspend fun getPlatformUrlByCredentialsServerToken(credentialsServerToken: String): String? = platforms
+        .firstOrNull { it.serverToken == credentialsServerToken }?.url
 
     override suspend fun getEndpoints(platformUrl: String): List<Endpoint> = platforms
         .firstOrNull { it.url == platformUrl }?.endpoints ?: emptyList()
@@ -76,38 +70,15 @@ open class PlatformCacheRepository : PlatformRepository {
     override suspend fun getVersion(platformUrl: String): Version? = platforms
         .firstOrNull { it.url == platformUrl }?.version
 
-    override suspend fun removeCredentialsTokenA(platformUrl: String) {
+    override suspend fun invalidateCredentialsTokenA(platformUrl: String): Boolean =
         platforms
             .getOrDefault(platformUrl, Platform(platformUrl))
             .copy(tokenA = null)
             .also { platforms[it.url!!] = it }
-    }
+            .let { true }
 
-    override suspend fun removeCredentialsTokenB(platformUrl: String) {
-        platforms
-            .getOrDefault(platformUrl, Platform(platformUrl))
-            .copy(tokenB = null)
-            .also { platforms[it.url!!] = it }
-    }
-
-    override suspend fun removeCredentialsTokenC(platformUrl: String) {
-        platforms
-            .getOrDefault(platformUrl, Platform(platformUrl))
-            .copy(tokenC = null)
-            .also { platforms[it.url!!] = it }
-    }
-
-    override suspend fun removeVersion(platformUrl: String) {
-        platforms
-            .getOrDefault(platformUrl, Platform(platformUrl))
-            .copy(version = null)
-            .also { platforms[it.url!!] = it }
-    }
-
-    override suspend fun removeEndpoints(platformUrl: String) {
-        platforms
-            .getOrDefault(platformUrl, Platform(platformUrl))
-            .copy(endpoints = null)
-            .also { platforms[it.url!!] = it }
+    override suspend fun unregisterPlatform(platformUrl: String): Boolean {
+        platforms[platformUrl] = Platform(platformUrl)
+        return true
     }
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsReceiver.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsReceiver.kt
@@ -1,6 +1,6 @@
 package com.izivia.ocpi.toolkit.samples.credentials
 
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.credentials.CredentialsServer
 import com.izivia.ocpi.toolkit.modules.credentials.domain.BusinessDetails
 import com.izivia.ocpi.toolkit.modules.credentials.domain.CredentialRole
@@ -27,7 +27,7 @@ fun main() {
     val receiverServer = Http4kTransportServer(
         baseUrl = receiverUrl,
         port = receiverPort,
-        secureFilter = receiverPlatformRepository::tokenFilter
+        secureFilter = receiverPlatformRepository::checkToken
     )
 
     runBlocking {

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsSender.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsSender.kt
@@ -1,6 +1,6 @@
 package com.izivia.ocpi.toolkit.samples.credentials
 
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.credentials.domain.BusinessDetails
 import com.izivia.ocpi.toolkit.modules.credentials.domain.CredentialRole
 import com.izivia.ocpi.toolkit.modules.credentials.domain.Role
@@ -28,7 +28,7 @@ fun main() {
     val senderServer = Http4kTransportServer(
         baseUrl = senderUrl,
         port = senderPort,
-        secureFilter = senderPlatformRepository::tokenFilter
+        secureFilter = senderPlatformRepository::checkToken
     )
 
     runBlocking {

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsCommon.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsCommon.kt
@@ -6,7 +6,7 @@ import com.izivia.ocpi.toolkit.samples.common.VersionDetailsCacheRepository
 import kotlinx.coroutines.runBlocking
 
 const val CREDENTIALS_TOKEN_C = "e0748bbe-d535-4a6b-8f80-94f2457d5b9d"
-val DUMMY_PLATFORM_REPOSITORY = DummyPlatformCacheRepository(tokenC = CREDENTIALS_TOKEN_C).also {
+val DUMMY_PLATFORM_REPOSITORY = DummyPlatformCacheRepository().also {
     val versionDetailsEmsp = VersionDetailsCacheRepository(baseUrl = emspServerUrl)
     val versionDetailsCpo = VersionDetailsCacheRepository(baseUrl = cpoServerUrl)
 

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsCpoServer.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsCpoServer.kt
@@ -1,7 +1,7 @@
 package com.izivia.ocpi.toolkit.samples.locations
 
 import com.izivia.ocpi.toolkit.common.SearchResult
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.locations.LocationsCpoServer
 import com.izivia.ocpi.toolkit.modules.locations.domain.Connector
 import com.izivia.ocpi.toolkit.modules.locations.domain.Evse
@@ -24,7 +24,7 @@ fun main() {
     val transportServer = Http4kTransportServer(
         baseUrl = cpoServerUrl,
         port = cpoServerPort,
-        secureFilter = DUMMY_PLATFORM_REPOSITORY::tokenFilter
+        secureFilter = DUMMY_PLATFORM_REPOSITORY::checkToken
     )
 
     // We specify service for the validation service

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsEmspServer.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsEmspServer.kt
@@ -1,6 +1,6 @@
 package com.izivia.ocpi.toolkit.samples.locations
 
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.locations.LocationsEmspServer
 import com.izivia.ocpi.toolkit.modules.locations.domain.*
 import com.izivia.ocpi.toolkit.modules.locations.repositories.LocationsEmspRepository
@@ -21,7 +21,7 @@ fun main() {
     val transportServer = Http4kTransportServer(
         baseUrl = emspServerUrl,
         port = emspServerPort,
-        secureFilter = DUMMY_PLATFORM_REPOSITORY::tokenFilter
+        secureFilter = DUMMY_PLATFORM_REPOSITORY::checkToken
     )
 
     // We specify service for the validation service

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/CredentialsIntegrationTests.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/CredentialsIntegrationTests.kt
@@ -26,6 +26,7 @@ import org.litote.kmongo.eq
 import org.litote.kmongo.getCollection
 import strikt.api.expectCatching
 import strikt.api.expectThat
+import strikt.api.expectThrows
 import strikt.assertions.*
 import java.util.*
 
@@ -561,16 +562,11 @@ class CredentialsIntegrationTests : BaseServerIntegrationTest() {
             credentialsClientService.delete()
         }
 
-        expectThat(
+        expectThrows<OcpiClientUnknownTokenException> {
+            // no token to use, so we should have an OCPI client error
             runBlocking {
                 versionsClient.getVersions()
             }
-        ) {
-            get { data }
-                .isNull()
-
-            get { status_code }
-                .isEqualTo(OcpiStatus.CLIENT_INVALID_PARAMETERS.code)
         }
     }
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/LocationsIntegrationTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/LocationsIntegrationTest.kt
@@ -28,7 +28,7 @@ class LocationsIntegrationTest : BaseServerIntegrationTest() {
         if (database == null) database = buildDBClient().getDatabase("ocpi-2-1-1-tests")
         val collection = database!!.getCollection<Location>("cpo-server-locations-${UUID.randomUUID()}")
         collection.insertMany(locations)
-        val server = buildTransportServer(DummyPlatformCacheRepository(tokenC = tokenC))
+        val server = buildTransportServer(DummyPlatformCacheRepository())
         runBlocking {
             LocationsCpoServer(
                 LocationsCpoService(
@@ -59,7 +59,7 @@ class LocationsIntegrationTest : BaseServerIntegrationTest() {
 
         val cpoServerVersionsUrl = "${cpoServer.baseUrl}/versions"
 
-        val platformRepo = DummyPlatformCacheRepository(tokenC = tokenC).also {
+        val platformRepo = DummyPlatformCacheRepository().also {
             val versionDetailsCpo = VersionDetailsCacheRepository(baseUrl = cpoServer.baseUrl)
 
             runBlocking {

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/common/BaseServerIntegrationTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/common/BaseServerIntegrationTest.kt
@@ -1,6 +1,6 @@
 package com.izivia.ocpi.toolkit.tests.integration.common
 
-import com.izivia.ocpi.toolkit.common.tokenFilter
+import com.izivia.ocpi.toolkit.common.checkToken
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PlatformRepository
 import com.izivia.ocpi.toolkit.samples.common.Http4kTransportClient
 import com.izivia.ocpi.toolkit.samples.common.Http4kTransportServer
@@ -18,7 +18,7 @@ abstract class BaseServerIntegrationTest : BaseDBIntegrationTest() {
             baseUrl = "http://localhost:$port",
             port = port
         ) {
-            platformRepository?.tokenFilter(it)
+            platformRepository?.checkToken(it)
         }
     }
 

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/common/BaseServerIntegrationTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/common/BaseServerIntegrationTest.kt
@@ -6,17 +6,20 @@ import com.izivia.ocpi.toolkit.samples.common.Http4kTransportClient
 import com.izivia.ocpi.toolkit.samples.common.Http4kTransportServer
 import java.net.ServerSocket
 
-abstract class BaseServerIntegrationTest: BaseDBIntegrationTest() {
+abstract class BaseServerIntegrationTest : BaseDBIntegrationTest() {
 
     private fun getFreeNetworkPort() = ServerSocket(0).use { it.localPort }
 
-    protected fun buildTransportServer(platformRepository: PlatformRepository? = null): Http4kTransportServer {
+    protected fun buildTransportServer(
+        platformRepository: PlatformRepository? = null
+    ): Http4kTransportServer {
         val port = getFreeNetworkPort()
         return Http4kTransportServer(
             baseUrl = "http://localhost:$port",
-            port = port,
-            secureFilter = platformRepository?.let { it::tokenFilter } ?: { }
-        )
+            port = port
+        ) {
+            platformRepository?.tokenFilter(it)
+        }
     }
 
     protected fun Http4kTransportServer.getClient() =


### PR DESCRIPTION
## Change notes

**only for 2.2.1**

**Credentials logic**

The credentials logic completely changed. Token B and Token C were replaced by Client Token and Server Token. The Token A usage stays the same.

The Credentials Token A is used by the sender to communicate with the receiver (only when initiating registration). After registration, it is invalidated.

Then, there are two tokens, and the token to use is specified by the registration process.
 - When you are the receiver during registration:
   - OCPI Token B is the client token, the one you have to use to send requests
   - OCPI Token C is the server token, the one you have to use to check if requests are properly authenticated
 - When you are the sender during registration:
   - OCPI Token B is the server token, the one you have to use to check if requests are properly authenticated
   - OCPI Token C is the client token, the one you have to use to send requests

This is why we do not use OCPI's token B and token C naming. According to who you are in the registration process, you have to use a different token. Using "Client Token" and "Server Token" simplifies that process of picking the right token for the right operation.

Before these changes, the library would not work when used while being the receiver of the registration process.

**PlatformRepository modifications**

Unused methods are removed. Some were renamed and their signature updated to match the new credentials logic. The unregistration is now in one unique method, rather than 5 different methods.
 
## Migration guide

It's a breaking change, it also breaks your `Platform` objects.

You will have to update your `PlatformRepository` implementation to match the new interface. Everything is documented in the file. You have to re-register with your partners. Or you can mnually update your `Platform` object to reflect the changes (clientToken / serverToken instead of tokenB / tokenC).

## Notes

This will allow us to bump the lib to 0.1.0 as it should now work properly, and it's now usable (not production ready yet obvisouly).
