### PR TITLE
fix(ocpi-2.2.1): path for PATCH evse and connector

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
@@ -185,7 +185,7 @@ class LocationsCpoClient(
         send(
             HttpRequest(
                 method = HttpMethod.PATCH,
-                path = "/$countryCode/$partyId/$locationId",
+                path = "/$countryCode/$partyId/$locationId/$evseUid",
                 body = mapper.writeValueAsString(evse)
             )
                 .withRequiredHeaders(
@@ -208,7 +208,7 @@ class LocationsCpoClient(
         send(
             HttpRequest(
                 method = HttpMethod.PATCH,
-                path = "/$countryCode/$partyId/$locationId",
+                path = "/$countryCode/$partyId/$locationId/$evseUid/$connectorId",
                 body = mapper.writeValueAsString(connector)
             )
                 .withRequiredHeaders(


### PR DESCRIPTION
Fix for issue #24

Did not bother checking v 2.1.1 as @lilgallon mentioned support for it will be dropped anyways.
Did not find any existing tests, so this is fix only.