### PR TITLE
fix(sessions) #42: Session.kwh should be BigDecimal

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/domain/Session.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/domain/Session.kt
@@ -6,6 +6,7 @@ import com.izivia.ocpi.toolkit.modules.cdr.domain.AuthMethod
 import com.izivia.ocpi.toolkit.modules.cdr.domain.CdrToken
 import com.izivia.ocpi.toolkit.modules.cdr.domain.ChargingPeriod
 import com.izivia.ocpi.toolkit.modules.types.Price
+import java.math.BigDecimal
 import java.time.Instant
 
 /**
@@ -75,7 +76,7 @@ data class Session(
     val id: CiString,
     val startDateTime: Instant,
     val endDateTime: Instant? = null,
-    val kwh: Int,
+    val kwh: BigDecimal,
     val cdrToken: CdrToken,
     val authMethod: AuthMethod,
     val authorizationReference: CiString? = null,

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/services/SessionsValidators.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/services/SessionsValidators.kt
@@ -19,7 +19,7 @@ fun SessionPartial.validate(): SessionPartial = validate(this) {
     validate(SessionPartial::id).isPrintableAscii().hasMaxLengthOf(36)
     // startDateTime nothing to validate
     // endDateTime nothing to validate
-    validate(SessionPartial::kwh).isGreaterThanOrEqualTo(0)
+    validate(SessionPartial::kwh).isGreaterThanOrEqualTo(BigDecimal.ZERO)
     cdrToken?.validate()
     // authMethod: nothing to validate
     validate(SessionPartial::authorizationReference).isPrintableAscii().hasMaxLengthOf(36)


### PR DESCRIPTION
Using same datatype as for Cdr.totalEnergy