### PR TITLE
feat(ci/cd) #44: Automatic Github release creation on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,3 +40,13 @@ jobs:
                     GPG_PRIVATE_KEY: ${{ secrets.DELIVERY_GPG_SECRET_KEY }}
                     GPG_PASSPHRASE: ${{ secrets.DELIVERY_GPG_KEY_PASSPHRASE }}
                 run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+
+            -   name: Create a GH release
+                env:
+                    VERSION: ${{ github.ref_name }}
+                    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                run: |-
+                    gh release create ${{ github.ref }} \
+                        --generate-notes \
+                        --title "Version ${VERSION#R-}" \
+                        ocpi-toolkit-2.2.1/build/libs/*.jar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ permissions:
     contents: read
 
 jobs:
-    build:
+    publish:
 
         concurrency: ocpi-publish
 
@@ -32,7 +32,7 @@ jobs:
                     cache-read-only: ${{ github.ref != 'refs/heads/main' }}
                     gradle-home-cache-cleanup: true
 
-            -   name: Build OCPI toolkit
+            -   name: Publish OCPI toolkit
                 env:
                     VERSION: ${{ github.ref }}
                     SONATYPE_USERNAME: ${{ secrets.DELIVERY_SONATYPE_USERNAME }}


### PR DESCRIPTION
- Tested there: https://github.com/lilgallon/ocpi-toolkit/actions/runs/7221032695/job/19675142201
- Produces the same releases as the one we already have, but with built artefacts, as you can see there https://github.com/lilgallon/ocpi-toolkit/releases/tag/R-0.0.27

I am open to critism