### PR TITLE
fix(credentials) throw OcpiServerUnsupportedVersionException when versions doesn't match

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
@@ -143,7 +143,7 @@ class CredentialsServerService(
             }
 
         val matchingVersion = versions.firstOrNull { it.version == VersionNumber.V2_2_1.value }
-            ?: throw OcpiServerNoMatchingEndpointsException("Expected version 2.2.1 from $versions")
+            ?: throw OcpiServerUnsupportedVersionException("Expected version 2.2.1 from $versions")
 
         partnerRepository.saveVersion(partnerUrl = credentials.url, version = matchingVersion)
 


### PR DESCRIPTION
Closes #52 