### PR TITLE
fix(ocpi-2.2.1) evseId must be optional

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/domain/Evse.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/domain/Evse.kt
@@ -42,7 +42,7 @@ import java.time.Instant
 @Partial
 data class Evse(
     val uid: CiString,
-    val evseId: CiString,
+    val evseId: CiString?,
     val status: Status,
     val statusSchedule: List<StatusSchedule>? = null,
     val capabilities: List<Capability>? = null,


### PR DESCRIPTION
Fixes #73 