### PR TITLE
feat(commands) #26: Implement Commands module

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpAuthInterface.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpAuthInterface.kt
@@ -1,0 +1,14 @@
+package com.izivia.ocpi.toolkit.common
+
+import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
+
+/**
+ * Example implementation
+ *
+ *     httpAuth = { req ->
+ *       partnerRepository.getPartnerUrlByCredentialsServerToken(req.parseAuthorizationHeader())!!
+ *     }
+ */
+fun interface HttpAuthInterface {
+    suspend fun partnerUrlFromRequest(req: HttpRequest): String
+}

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoClient.kt
@@ -9,12 +9,12 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 
 class CommandCpoClient(
     private val transportClientBuilder: TransportClientBuilder,
-    private val partnerRepository: PartnerRepository,
+    private val partnerRepository: PartnerRepository
 ) {
     suspend fun postCommandCallback(
         commandResult: CommandResult,
         partnerUrl: String,
-        responseUrl: String,
+        responseUrl: String
     ): OcpiResponseBody<Any> =
         transportClientBuilder
             .build("")

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoClient.kt
@@ -1,0 +1,33 @@
+package com.izivia.ocpi.toolkit.modules.commands
+
+import com.izivia.ocpi.toolkit.common.*
+import com.izivia.ocpi.toolkit.modules.commands.domain.CommandResult
+import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
+import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
+import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
+import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
+
+class CommandCpoClient(
+    private val transportClientBuilder: TransportClientBuilder,
+    private val partnerRepository: PartnerRepository,
+) {
+    suspend fun postCommandCallback(
+        commandResult: CommandResult,
+        partnerUrl: String,
+        responseUrl: String,
+    ): OcpiResponseBody<Any> =
+        transportClientBuilder
+            .build("")
+            .send(
+                HttpRequest(
+                    method = HttpMethod.POST,
+                    path = responseUrl,
+                    body = mapper.writeValueAsString(commandResult)
+                )
+                    .withRequiredHeaders(
+                        requestId = generateUUIDv4Token(),
+                        correlationId = generateUUIDv4Token()
+                    )
+                    .authenticate(partnerRepository = partnerRepository, partnerUrl = partnerUrl)
+            ).parseBody()
+}

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoInterface.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoInterface.kt
@@ -6,26 +6,26 @@ import com.izivia.ocpi.toolkit.modules.commands.domain.*
 interface CommandCpoInterface {
     suspend fun postStartSession(
         partnerUrl: String,
-        startSession: StartSession,
+        startSession: StartSession
     ): OcpiResponseBody<CommandResponse>
 
     suspend fun postStopSession(
         partnerUrl: String,
-        stopSession: StopSession,
+        stopSession: StopSession
     ): OcpiResponseBody<CommandResponse>
 
     suspend fun postReserveNow(
         partnerUrl: String,
-        reserveNow: ReserveNow,
+        reserveNow: ReserveNow
     ): OcpiResponseBody<CommandResponse>
 
     suspend fun postCancelReservation(
         partnerUrl: String,
-        cancelReservation: CancelReservation,
+        cancelReservation: CancelReservation
     ): OcpiResponseBody<CommandResponse>
 
     suspend fun postUnlockConnector(
         partnerUrl: String,
-        unlockConnector: UnlockConnector,
+        unlockConnector: UnlockConnector
     ): OcpiResponseBody<CommandResponse>
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoInterface.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoInterface.kt
@@ -1,0 +1,31 @@
+package com.izivia.ocpi.toolkit.modules.commands
+
+import com.izivia.ocpi.toolkit.common.OcpiResponseBody
+import com.izivia.ocpi.toolkit.modules.commands.domain.*
+
+interface CommandCpoInterface {
+    suspend fun postStartSession(
+        partnerUrl: String,
+        startSession: StartSession,
+    ): OcpiResponseBody<CommandResponse>
+
+    suspend fun postStopSession(
+        partnerUrl: String,
+        stopSession: StopSession,
+    ): OcpiResponseBody<CommandResponse>
+
+    suspend fun postReserveNow(
+        partnerUrl: String,
+        reserveNow: ReserveNow,
+    ): OcpiResponseBody<CommandResponse>
+
+    suspend fun postCancelReservation(
+        partnerUrl: String,
+        cancelReservation: CancelReservation,
+    ): OcpiResponseBody<CommandResponse>
+
+    suspend fun postUnlockConnector(
+        partnerUrl: String,
+        unlockConnector: UnlockConnector,
+    ): OcpiResponseBody<CommandResponse>
+}

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoServer.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoServer.kt
@@ -17,7 +17,7 @@ class CommandCpoServer(
     private val httpAuth: HttpAuthInterface,
     private val service: CommandCpoInterface,
     versionsRepository: MutableVersionsRepository? = null,
-    basePathOverride: String? = null,
+    basePathOverride: String? = null
 ) : OcpiSelfRegisteringModuleServer(
     ocpiVersion = VersionNumber.V2_2_1,
     moduleID = ModuleID.commands,
@@ -29,7 +29,7 @@ class CommandCpoServer(
     override suspend fun doRegisterOn(transportServer: TransportServer) {
         transportServer.handle(
             method = HttpMethod.POST,
-            path = basePathSegments + FixedPathSegment("START_SESSION"),
+            path = basePathSegments + FixedPathSegment("START_SESSION")
         ) { req ->
             val senderPlatformUrl = httpAuth.partnerUrlFromRequest(req)
             val startSession = mapper.readValue(req.body, StartSession::class.java)
@@ -41,7 +41,7 @@ class CommandCpoServer(
 
         transportServer.handle(
             method = HttpMethod.POST,
-            path = basePathSegments + FixedPathSegment("STOP_SESSION"),
+            path = basePathSegments + FixedPathSegment("STOP_SESSION")
         ) { req ->
             val senderPlatformUrl = httpAuth.partnerUrlFromRequest(req)
             val stopSession = mapper.readValue(req.body, StopSession::class.java)
@@ -53,7 +53,7 @@ class CommandCpoServer(
 
         transportServer.handle(
             method = HttpMethod.POST,
-            path = basePathSegments + FixedPathSegment("RESERVE_NOW"),
+            path = basePathSegments + FixedPathSegment("RESERVE_NOW")
         ) { req ->
             val senderPlatformUrl = httpAuth.partnerUrlFromRequest(req)
             val reserveNow = mapper.readValue(req.body, ReserveNow::class.java)
@@ -65,7 +65,7 @@ class CommandCpoServer(
 
         transportServer.handle(
             method = HttpMethod.POST,
-            path = basePathSegments + FixedPathSegment("CANCEL_RESERVATION"),
+            path = basePathSegments + FixedPathSegment("CANCEL_RESERVATION")
         ) { req ->
             val senderPlatformUrl = httpAuth.partnerUrlFromRequest(req)
             val cancelReservation = mapper.readValue(req.body, CancelReservation::class.java)
@@ -77,7 +77,7 @@ class CommandCpoServer(
 
         transportServer.handle(
             method = HttpMethod.POST,
-            path = basePathSegments + FixedPathSegment("UNLOCK_CONNECTOR"),
+            path = basePathSegments + FixedPathSegment("UNLOCK_CONNECTOR")
         ) { req ->
             val senderPlatformUrl = httpAuth.partnerUrlFromRequest(req)
             val unlockConnector = mapper.readValue(req.body, UnlockConnector::class.java)

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoServer.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoServer.kt
@@ -1,0 +1,90 @@
+package com.izivia.ocpi.toolkit.modules.commands
+
+import com.izivia.ocpi.toolkit.common.HttpAuthInterface
+import com.izivia.ocpi.toolkit.common.OcpiSelfRegisteringModuleServer
+import com.izivia.ocpi.toolkit.common.httpResponse
+import com.izivia.ocpi.toolkit.common.mapper
+import com.izivia.ocpi.toolkit.modules.commands.domain.*
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
+import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
+import com.izivia.ocpi.toolkit.modules.versions.domain.VersionNumber
+import com.izivia.ocpi.toolkit.modules.versions.repositories.MutableVersionsRepository
+import com.izivia.ocpi.toolkit.transport.TransportServer
+import com.izivia.ocpi.toolkit.transport.domain.FixedPathSegment
+import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
+
+class CommandCpoServer(
+    private val httpAuth: HttpAuthInterface,
+    private val service: CommandCpoInterface,
+    versionsRepository: MutableVersionsRepository? = null,
+    basePathOverride: String? = null,
+) : OcpiSelfRegisteringModuleServer(
+    ocpiVersion = VersionNumber.V2_2_1,
+    moduleID = ModuleID.commands,
+    interfaceRole = InterfaceRole.RECEIVER,
+    versionsRepository = versionsRepository,
+    basePathOverride = basePathOverride
+) {
+
+    override suspend fun doRegisterOn(transportServer: TransportServer) {
+        transportServer.handle(
+            method = HttpMethod.POST,
+            path = basePathSegments + FixedPathSegment("START_SESSION"),
+        ) { req ->
+            val senderPlatformUrl = httpAuth.partnerUrlFromRequest(req)
+            val startSession = mapper.readValue(req.body, StartSession::class.java)
+
+            req.httpResponse {
+                service.postStartSession(senderPlatformUrl, startSession)
+            }
+        }
+
+        transportServer.handle(
+            method = HttpMethod.POST,
+            path = basePathSegments + FixedPathSegment("STOP_SESSION"),
+        ) { req ->
+            val senderPlatformUrl = httpAuth.partnerUrlFromRequest(req)
+            val stopSession = mapper.readValue(req.body, StopSession::class.java)
+
+            req.httpResponse {
+                service.postStopSession(senderPlatformUrl, stopSession = stopSession)
+            }
+        }
+
+        transportServer.handle(
+            method = HttpMethod.POST,
+            path = basePathSegments + FixedPathSegment("RESERVE_NOW"),
+        ) { req ->
+            val senderPlatformUrl = httpAuth.partnerUrlFromRequest(req)
+            val reserveNow = mapper.readValue(req.body, ReserveNow::class.java)
+
+            req.httpResponse {
+                service.postReserveNow(senderPlatformUrl, reserveNow)
+            }
+        }
+
+        transportServer.handle(
+            method = HttpMethod.POST,
+            path = basePathSegments + FixedPathSegment("CANCEL_RESERVATION"),
+        ) { req ->
+            val senderPlatformUrl = httpAuth.partnerUrlFromRequest(req)
+            val cancelReservation = mapper.readValue(req.body, CancelReservation::class.java)
+
+            req.httpResponse {
+                service.postCancelReservation(senderPlatformUrl, cancelReservation)
+            }
+        }
+
+        transportServer.handle(
+            method = HttpMethod.POST,
+            path = basePathSegments + FixedPathSegment("UNLOCK_CONNECTOR"),
+        ) { req ->
+            val senderPlatformUrl = httpAuth.partnerUrlFromRequest(req)
+            val unlockConnector = mapper.readValue(req.body, UnlockConnector::class.java)
+
+            req.httpResponse {
+                service.postUnlockConnector(senderPlatformUrl, unlockConnector)
+            }
+        }
+    }
+}

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspClient.kt
@@ -15,7 +15,7 @@ class CommandEmspClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val serverVersionsEndpointUrl: String,
     private val partnerRepository: PartnerRepository,
-    private val callbackBaseUrl: String,
+    private val callbackBaseUrl: String
 ) {
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
@@ -30,7 +30,7 @@ class CommandEmspClient(
         locationId: CiString,
         evseId: CiString?,
         connectorId: CiString?,
-        authorizationReference: CiString,
+        authorizationReference: CiString
     ): OcpiResponseBody<CommandResponse> =
         with(buildTransport()) {
             send(
@@ -39,12 +39,12 @@ class CommandEmspClient(
                     path = "/START_SESSION",
                     body = mapper.writeValueAsString(
                         StartSession(
-                            responseUrl = "${callbackBaseUrl}/START_SESSION/callback/${authorizationReference}",
+                            responseUrl = "$callbackBaseUrl/START_SESSION/callback/$authorizationReference",
                             token = token,
                             locationId = locationId,
                             evseUid = evseId,
                             connectorId = connectorId,
-                            authorizationReference = authorizationReference,
+                            authorizationReference = authorizationReference
                         )
                     )
                 )
@@ -65,8 +65,8 @@ class CommandEmspClient(
                     path = "/STOP_SESSION",
                     body = mapper.writeValueAsString(
                         StopSession(
-                            responseUrl = "${callbackBaseUrl}/STOP_SESSION/callback/${sessionId}",
-                            sessionId = sessionId,
+                            responseUrl = "$callbackBaseUrl/STOP_SESSION/callback/$sessionId",
+                            sessionId = sessionId
                         )
                     )
                 )
@@ -85,7 +85,7 @@ class CommandEmspClient(
         reservationId: CiString,
         locationId: CiString,
         evseUid: CiString?,
-        authorizationReference: CiString?,
+        authorizationReference: CiString?
     ): OcpiResponseBody<CommandResponse> =
         with(buildTransport()) {
             send(
@@ -94,13 +94,13 @@ class CommandEmspClient(
                     path = "/RESERVE_NOW",
                     body = mapper.writeValueAsString(
                         ReserveNow(
-                            responseUrl = "${callbackBaseUrl}/RESERVE_NOW/callback/${reservationId}",
+                            responseUrl = "$callbackBaseUrl/RESERVE_NOW/callback/$reservationId",
                             token = token,
                             expiryDate = expiryDate,
                             reservationId = reservationId,
                             locationId = locationId,
                             evseUid = evseUid,
-                            authorizationReference = authorizationReference,
+                            authorizationReference = authorizationReference
                         )
                     )
                 )
@@ -121,8 +121,8 @@ class CommandEmspClient(
                     path = "/CANCEL_RESERVATION",
                     body = mapper.writeValueAsString(
                         CancelReservation(
-                            responseUrl = "${callbackBaseUrl}/CANCEL_RESERVATION/callback/${reservationId}",
-                            reservationId = reservationId,
+                            responseUrl = "$callbackBaseUrl/CANCEL_RESERVATION/callback/$reservationId",
+                            reservationId = reservationId
                         )
                     )
                 )
@@ -138,7 +138,7 @@ class CommandEmspClient(
     suspend fun postUnlockConnector(
         locationId: CiString,
         evseUid: CiString,
-        connectorId: CiString,
+        connectorId: CiString
     ): OcpiResponseBody<CommandResponse> =
         with(buildTransport()) {
             send(
@@ -147,10 +147,11 @@ class CommandEmspClient(
                     path = "/UNLOCK_CONNECTOR",
                     body = mapper.writeValueAsString(
                         UnlockConnector(
-                            responseUrl = "${callbackBaseUrl}/UNLOCK_CONNECTOR/callback/${locationId}/${evseUid}/${connectorId}",
+                            responseUrl =
+                            "$callbackBaseUrl/UNLOCK_CONNECTOR/callback/$locationId/$evseUid/$connectorId",
                             locationId = locationId,
                             evseUid = evseUid,
-                            connectorId = connectorId,
+                            connectorId = connectorId
                         )
                     )
                 )

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspClient.kt
@@ -1,0 +1,165 @@
+package com.izivia.ocpi.toolkit.modules.commands
+
+import com.izivia.ocpi.toolkit.common.*
+import com.izivia.ocpi.toolkit.modules.commands.domain.*
+import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
+import com.izivia.ocpi.toolkit.modules.tokens.domain.Token
+import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
+import com.izivia.ocpi.toolkit.transport.TransportClient
+import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
+import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
+import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
+import java.time.Instant
+
+class CommandEmspClient(
+    private val transportClientBuilder: TransportClientBuilder,
+    private val serverVersionsEndpointUrl: String,
+    private val partnerRepository: PartnerRepository,
+    private val callbackBaseUrl: String,
+) {
+
+    private suspend fun buildTransport(): TransportClient = transportClientBuilder
+        .buildFor(
+            module = ModuleID.commands,
+            partnerUrl = serverVersionsEndpointUrl,
+            partnerRepository = partnerRepository
+        )
+
+    suspend fun postStartSession(
+        token: Token,
+        locationId: CiString,
+        evseId: CiString?,
+        connectorId: CiString?,
+        authorizationReference: CiString,
+    ): OcpiResponseBody<CommandResponse> =
+        with(buildTransport()) {
+            send(
+                HttpRequest(
+                    method = HttpMethod.POST,
+                    path = "/START_SESSION",
+                    body = mapper.writeValueAsString(
+                        StartSession(
+                            responseUrl = "${callbackBaseUrl}/START_SESSION/callback/${authorizationReference}",
+                            token = token,
+                            locationId = locationId,
+                            evseUid = evseId,
+                            connectorId = connectorId,
+                            authorizationReference = authorizationReference,
+                        )
+                    )
+                )
+                    .withRequiredHeaders(
+                        requestId = generateUUIDv4Token(),
+                        correlationId = generateUUIDv4Token()
+                    )
+                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+            )
+                .parseBody()
+        }
+
+    suspend fun postStopSession(sessionId: String): OcpiResponseBody<CommandResponse> =
+        with(buildTransport()) {
+            send(
+                HttpRequest(
+                    method = HttpMethod.POST,
+                    path = "/STOP_SESSION",
+                    body = mapper.writeValueAsString(
+                        StopSession(
+                            responseUrl = "${callbackBaseUrl}/STOP_SESSION/callback/${sessionId}",
+                            sessionId = sessionId,
+                        )
+                    )
+                )
+                    .withRequiredHeaders(
+                        requestId = generateUUIDv4Token(),
+                        correlationId = generateUUIDv4Token()
+                    )
+                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+            )
+                .parseBody()
+        }
+
+    suspend fun postReserveNow(
+        token: Token,
+        expiryDate: Instant,
+        reservationId: CiString,
+        locationId: CiString,
+        evseUid: CiString?,
+        authorizationReference: CiString?,
+    ): OcpiResponseBody<CommandResponse> =
+        with(buildTransport()) {
+            send(
+                HttpRequest(
+                    method = HttpMethod.POST,
+                    path = "/RESERVE_NOW",
+                    body = mapper.writeValueAsString(
+                        ReserveNow(
+                            responseUrl = "${callbackBaseUrl}/RESERVE_NOW/callback/${reservationId}",
+                            token = token,
+                            expiryDate = expiryDate,
+                            reservationId = reservationId,
+                            locationId = locationId,
+                            evseUid = evseUid,
+                            authorizationReference = authorizationReference,
+                        )
+                    )
+                )
+                    .withRequiredHeaders(
+                        requestId = generateUUIDv4Token(),
+                        correlationId = generateUUIDv4Token()
+                    )
+                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+            )
+                .parseBody()
+        }
+
+    suspend fun postCancelReservation(reservationId: CiString): OcpiResponseBody<CommandResponse> =
+        with(buildTransport()) {
+            send(
+                HttpRequest(
+                    method = HttpMethod.POST,
+                    path = "/CANCEL_RESERVATION",
+                    body = mapper.writeValueAsString(
+                        CancelReservation(
+                            responseUrl = "${callbackBaseUrl}/CANCEL_RESERVATION/callback/${reservationId}",
+                            reservationId = reservationId,
+                        )
+                    )
+                )
+                    .withRequiredHeaders(
+                        requestId = generateUUIDv4Token(),
+                        correlationId = generateUUIDv4Token()
+                    )
+                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+            )
+                .parseBody()
+        }
+
+    suspend fun postUnlockConnector(
+        locationId: CiString,
+        evseUid: CiString,
+        connectorId: CiString,
+    ): OcpiResponseBody<CommandResponse> =
+        with(buildTransport()) {
+            send(
+                HttpRequest(
+                    method = HttpMethod.POST,
+                    path = "/UNLOCK_CONNECTOR",
+                    body = mapper.writeValueAsString(
+                        UnlockConnector(
+                            responseUrl = "${callbackBaseUrl}/UNLOCK_CONNECTOR/callback/${locationId}/${evseUid}/${connectorId}",
+                            locationId = locationId,
+                            evseUid = evseUid,
+                            connectorId = connectorId,
+                        )
+                    )
+                )
+                    .withRequiredHeaders(
+                        requestId = generateUUIDv4Token(),
+                        correlationId = generateUUIDv4Token()
+                    )
+                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+            )
+                .parseBody()
+        }
+}

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspInterface.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspInterface.kt
@@ -1,0 +1,24 @@
+package com.izivia.ocpi.toolkit.modules.commands
+
+import com.izivia.ocpi.toolkit.common.OcpiResponseBody
+import com.izivia.ocpi.toolkit.modules.commands.domain.CommandResult
+
+interface CommandEmspInterface {
+    suspend fun postCallbackStartSession(
+        authorizationReference: String,
+        result: CommandResult,
+    ): OcpiResponseBody<String>
+
+    suspend fun postCallbackStopSession(sessionId: String, result: CommandResult): OcpiResponseBody<String>
+
+    suspend fun postCallbackReserveNow(reservationId: String, result: CommandResult): OcpiResponseBody<String>
+
+    suspend fun postCallbackCancelReservation(reservationId: String, result: CommandResult): OcpiResponseBody<String>
+
+    suspend fun postCallbackUnlockConnector(
+        locationId: String,
+        evseId: String,
+        connectorId: String,
+        result: CommandResult,
+    ): OcpiResponseBody<String>
+}

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspInterface.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspInterface.kt
@@ -6,7 +6,7 @@ import com.izivia.ocpi.toolkit.modules.commands.domain.CommandResult
 interface CommandEmspInterface {
     suspend fun postCallbackStartSession(
         authorizationReference: String,
-        result: CommandResult,
+        result: CommandResult
     ): OcpiResponseBody<String>
 
     suspend fun postCallbackStopSession(sessionId: String, result: CommandResult): OcpiResponseBody<String>
@@ -19,6 +19,6 @@ interface CommandEmspInterface {
         locationId: String,
         evseId: String,
         connectorId: String,
-        result: CommandResult,
+        result: CommandResult
     ): OcpiResponseBody<String>
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspServer.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspServer.kt
@@ -1,0 +1,108 @@
+package com.izivia.ocpi.toolkit.modules.commands
+
+import com.izivia.ocpi.toolkit.common.OcpiSelfRegisteringModuleServer
+import com.izivia.ocpi.toolkit.common.httpResponse
+import com.izivia.ocpi.toolkit.common.mapper
+import com.izivia.ocpi.toolkit.modules.commands.domain.CommandResult
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
+import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
+import com.izivia.ocpi.toolkit.modules.versions.domain.VersionNumber
+import com.izivia.ocpi.toolkit.modules.versions.repositories.MutableVersionsRepository
+import com.izivia.ocpi.toolkit.transport.TransportServer
+import com.izivia.ocpi.toolkit.transport.domain.FixedPathSegment
+import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
+import com.izivia.ocpi.toolkit.transport.domain.VariablePathSegment
+
+class CommandEmspServer(
+    private val service: CommandEmspInterface,
+    versionsRepository: MutableVersionsRepository? = null,
+    basePathOverride: String? = null,
+) : OcpiSelfRegisteringModuleServer(
+    ocpiVersion = VersionNumber.V2_2_1,
+    moduleID = ModuleID.commands,
+    interfaceRole = InterfaceRole.SENDER,
+    versionsRepository = versionsRepository,
+    basePathOverride = basePathOverride
+) {
+
+    override suspend fun doRegisterOn(transportServer: TransportServer) {
+        transportServer.handle(
+            method = HttpMethod.POST,
+            path = basePathSegments + listOf(
+                FixedPathSegment("START_SESSION/callback"),
+                VariablePathSegment("authRef"),
+            ),
+        ) { req ->
+            req.httpResponse {
+                service.postCallbackStartSession(
+                    req.pathParams["authRef"]!!,
+                    result = mapper.readValue(req.body, CommandResult::class.java)
+                )
+            }
+        }
+
+        transportServer.handle(
+            method = HttpMethod.POST,
+            path = basePathSegments + listOf(
+                FixedPathSegment("STOP_SESSION/callback"),
+                VariablePathSegment("sessionId"),
+            ),
+        ) { req ->
+            req.httpResponse {
+                service.postCallbackStopSession(
+                    req.pathParams["sessionId"]!!,
+                    result = mapper.readValue(req.body, CommandResult::class.java),
+                )
+            }
+        }
+
+        transportServer.handle(
+            method = HttpMethod.POST,
+            path = basePathSegments + listOf(
+                FixedPathSegment("RESERVE_NOW/callback"),
+                VariablePathSegment("reservationId"),
+            ),
+        ) { req ->
+            req.httpResponse {
+                service.postCallbackReserveNow(
+                    req.pathParams["reservationId"]!!,
+                    result = mapper.readValue(req.body, CommandResult::class.java),
+                )
+            }
+        }
+
+        transportServer.handle(
+            method = HttpMethod.POST,
+            path = basePathSegments + listOf(
+                FixedPathSegment("CANCEL_RESERVATION/callback"),
+                VariablePathSegment("reservationId"),
+            ),
+        ) { req ->
+            req.httpResponse {
+                service.postCallbackCancelReservation(
+                    req.pathParams["reservationId"]!!,
+                    result = mapper.readValue(req.body, CommandResult::class.java),
+                )
+            }
+        }
+
+        transportServer.handle(
+            method = HttpMethod.POST,
+            path = basePathSegments + listOf(
+                FixedPathSegment("UNLOCK_CONNECTOR/callback"),
+                VariablePathSegment("locationId"),
+                VariablePathSegment("evseId"),
+                VariablePathSegment("connectorId"),
+            ),
+        ) { req ->
+            req.httpResponse {
+                service.postCallbackUnlockConnector(
+                    req.pathParams["locationId"]!!,
+                    req.pathParams["evseId"]!!,
+                    req.pathParams["connectorId"]!!,
+                    result = mapper.readValue(req.body, CommandResult::class.java),
+                )
+            }
+        }
+    }
+}

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspServer.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspServer.kt
@@ -16,7 +16,7 @@ import com.izivia.ocpi.toolkit.transport.domain.VariablePathSegment
 class CommandEmspServer(
     private val service: CommandEmspInterface,
     versionsRepository: MutableVersionsRepository? = null,
-    basePathOverride: String? = null,
+    basePathOverride: String? = null
 ) : OcpiSelfRegisteringModuleServer(
     ocpiVersion = VersionNumber.V2_2_1,
     moduleID = ModuleID.commands,
@@ -30,8 +30,8 @@ class CommandEmspServer(
             method = HttpMethod.POST,
             path = basePathSegments + listOf(
                 FixedPathSegment("START_SESSION/callback"),
-                VariablePathSegment("authRef"),
-            ),
+                VariablePathSegment("authRef")
+            )
         ) { req ->
             req.httpResponse {
                 service.postCallbackStartSession(
@@ -45,13 +45,13 @@ class CommandEmspServer(
             method = HttpMethod.POST,
             path = basePathSegments + listOf(
                 FixedPathSegment("STOP_SESSION/callback"),
-                VariablePathSegment("sessionId"),
-            ),
+                VariablePathSegment("sessionId")
+            )
         ) { req ->
             req.httpResponse {
                 service.postCallbackStopSession(
                     req.pathParams["sessionId"]!!,
-                    result = mapper.readValue(req.body, CommandResult::class.java),
+                    result = mapper.readValue(req.body, CommandResult::class.java)
                 )
             }
         }
@@ -60,13 +60,13 @@ class CommandEmspServer(
             method = HttpMethod.POST,
             path = basePathSegments + listOf(
                 FixedPathSegment("RESERVE_NOW/callback"),
-                VariablePathSegment("reservationId"),
-            ),
+                VariablePathSegment("reservationId")
+            )
         ) { req ->
             req.httpResponse {
                 service.postCallbackReserveNow(
                     req.pathParams["reservationId"]!!,
-                    result = mapper.readValue(req.body, CommandResult::class.java),
+                    result = mapper.readValue(req.body, CommandResult::class.java)
                 )
             }
         }
@@ -75,13 +75,13 @@ class CommandEmspServer(
             method = HttpMethod.POST,
             path = basePathSegments + listOf(
                 FixedPathSegment("CANCEL_RESERVATION/callback"),
-                VariablePathSegment("reservationId"),
-            ),
+                VariablePathSegment("reservationId")
+            )
         ) { req ->
             req.httpResponse {
                 service.postCallbackCancelReservation(
                     req.pathParams["reservationId"]!!,
-                    result = mapper.readValue(req.body, CommandResult::class.java),
+                    result = mapper.readValue(req.body, CommandResult::class.java)
                 )
             }
         }
@@ -92,15 +92,15 @@ class CommandEmspServer(
                 FixedPathSegment("UNLOCK_CONNECTOR/callback"),
                 VariablePathSegment("locationId"),
                 VariablePathSegment("evseId"),
-                VariablePathSegment("connectorId"),
-            ),
+                VariablePathSegment("connectorId")
+            )
         ) { req ->
             req.httpResponse {
                 service.postCallbackUnlockConnector(
                     req.pathParams["locationId"]!!,
                     req.pathParams["evseId"]!!,
                     req.pathParams["connectorId"]!!,
-                    result = mapper.readValue(req.body, CommandResult::class.java),
+                    result = mapper.readValue(req.body, CommandResult::class.java)
                 )
             }
         }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CancelReservation.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CancelReservation.kt
@@ -11,5 +11,5 @@ import com.izivia.ocpi.toolkit.common.CiString
  */
 data class CancelReservation(
     val responseUrl: CiString,
-    val reservationId: CiString,
+    val reservationId: CiString
 )

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CancelReservation.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CancelReservation.kt
@@ -1,0 +1,15 @@
+package com.izivia.ocpi.toolkit.modules.commands.domain
+
+import com.izivia.ocpi.toolkit.common.CiString
+
+/**
+ * @property responseUrl (max-length=255) URL that the CommandResult POST should be sent to. This URL might contain a
+ * unique ID to be able to distinguish between CancelReservation requests.
+ *
+ * @property reservationId (max-length=36) Reservation id, unique for this reservation. If the Charge Point already has
+ * a reservation that matches this reservationId the Charge Point will replace the reservation.
+ */
+data class CancelReservation(
+    val responseUrl: CiString,
+    val reservationId: CiString,
+)

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResponse.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResponse.kt
@@ -1,0 +1,18 @@
+package com.izivia.ocpi.toolkit.modules.commands.domain
+
+import com.izivia.ocpi.toolkit.modules.types.DisplayText
+
+/**
+ * @property result Response from the CPO on the command request.
+ *
+ * @property timeout Timeout for this command in seconds. When the Result is not received within this timeout, the eMSP
+ * can assume that the message might never be send.
+ *
+ * @property message Human-readable description of the result (if one can be provided), multiple languages can be
+ * provided.
+ */
+data class CommandResponse(
+    val result: CommandResponseType,
+    val timeout: Int,
+    val message: List<DisplayText>,
+)

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResponse.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResponse.kt
@@ -14,5 +14,5 @@ import com.izivia.ocpi.toolkit.modules.types.DisplayText
 data class CommandResponse(
     val result: CommandResponseType,
     val timeout: Int,
-    val message: List<DisplayText>,
+    val message: List<DisplayText>
 )

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResponseType.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResponseType.kt
@@ -19,5 +19,5 @@ enum class CommandResponseType {
     /**
      * The Session in the requested command is not known by this CPO.
      */
-    UNKNOWN_SESSION,
+    UNKNOWN_SESSION
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResponseType.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResponseType.kt
@@ -1,0 +1,23 @@
+package com.izivia.ocpi.toolkit.modules.commands.domain
+
+enum class CommandResponseType {
+    /**
+     *  The requested command is not supported by this CPO, Charge Point, EVSE etc.
+     */
+    NOT_SUPPORTED,
+
+    /**
+     * Command request rejected by the CPO. (Session might not be from a customer of the eMSP that send this request)
+     */
+    REJECTED,
+
+    /**
+     * Command request accepted by the CPO.
+     */
+    ACCEPTED,
+
+    /**
+     * The Session in the requested command is not known by this CPO.
+     */
+    UNKNOWN_SESSION,
+}

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResult.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResult.kt
@@ -10,5 +10,5 @@ import com.izivia.ocpi.toolkit.modules.types.DisplayText
  */
 data class CommandResult(
     val result: CommandResultType,
-    val message: List<DisplayText>,
+    val message: List<DisplayText>
 )

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResult.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResult.kt
@@ -1,0 +1,14 @@
+package com.izivia.ocpi.toolkit.modules.commands.domain
+
+import com.izivia.ocpi.toolkit.modules.types.DisplayText
+
+/**
+ * @property result Result of the command request as sent by the Charge Point to the CPO.
+ *
+ * @property message Human-readable description of the reason (if one can be provided), multiple languages can be
+ * provided.
+ */
+data class CommandResult(
+    val result: CommandResultType,
+    val message: List<DisplayText>,
+)

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResultType.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResultType.kt
@@ -1,0 +1,48 @@
+package com.izivia.ocpi.toolkit.modules.commands.domain
+
+enum class CommandResultType {
+    /**
+     * Command request accepted by the Charge Point.
+     */
+    ACCEPTED,
+
+    /**
+     * The Reservation has been canceled by the CPO.
+     */
+    CANCELED_RESERVATION,
+
+    /**
+     * EVSE is currently occupied, another session is ongoing. Cannot start a new session
+     */
+    EVSE_OCCUPIED,
+
+    /**
+     * EVSE is currently inoperative or faulted.
+     */
+    EVSE_INOPERATIVE,
+
+    /**
+     * Execution of the command failed at the Charge Point.
+     */
+    FAILED,
+
+    /**
+     * The requested command is not supported by this Charge Point, EVSE etc.
+     */
+    NOT_SUPPORTED,
+
+    /**
+     * Command request rejected by the Charge Point.
+     */
+    REJECTED,
+
+    /**
+     * Command request timeout, no response received from the Charge Point in a reasonable time.
+     */
+    TIMEOUT,
+
+    /**
+     * The Reservation in the requested command is not known by this Charge Point.
+     */
+    UNKNOWN_RESERVATION,
+}

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResultType.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResultType.kt
@@ -44,5 +44,5 @@ enum class CommandResultType {
     /**
      * The Reservation in the requested command is not known by this Charge Point.
      */
-    UNKNOWN_RESERVATION,
+    UNKNOWN_RESERVATION
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/ReserveNow.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/ReserveNow.kt
@@ -31,5 +31,5 @@ data class ReserveNow(
     val reservationId: CiString,
     val locationId: CiString,
     val evseUid: CiString?,
-    val authorizationReference: CiString?,
+    val authorizationReference: CiString?
 )

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/ReserveNow.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/ReserveNow.kt
@@ -1,0 +1,35 @@
+package com.izivia.ocpi.toolkit.modules.commands.domain
+
+import com.izivia.ocpi.toolkit.common.CiString
+import com.izivia.ocpi.toolkit.modules.tokens.domain.Token
+import java.time.Instant
+
+/**
+ * @property responseUrl (max-length=255) URL that the CommandResult POST should be sent to. This URL might contain a
+ * unique ID to be able to distinguish between ReserveNow requests.
+ *
+ * @property token Token object for how to reserve this Charge Point (and specific EVSE).
+ *
+ * @property expiryDate The Date/Time when this reservation ends, in UTC.
+ *
+ * @property reservationId (max-length=36) Reservation id, unique for this reservation. If the Receiver (typically CPO)
+ * Point already has a reservation that matches this reservationId for that Location it will replace the reservation.
+ *
+ * @property locationId (max-length=36) Location.id of the Location (belonging to the CPO this request is sent to) for
+ * which to reserve an EVSE.
+ *
+ * @property evseUid (max-length=36) Optional EVSE.uid of the EVSE of this Location if a specific EVSE has to be
+ * reserved.
+ *
+ * @property authorizationReference (max-length=36) Reference to the authorization given by the eMSP, when given, this
+ * reference will be provided in the relevant Session and/or CDR.
+ */
+data class ReserveNow(
+    val responseUrl: CiString,
+    val token: Token,
+    val expiryDate: Instant,
+    val reservationId: CiString,
+    val locationId: CiString,
+    val evseUid: CiString?,
+    val authorizationReference: CiString?,
+)

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/StartSession.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/StartSession.kt
@@ -1,0 +1,32 @@
+package com.izivia.ocpi.toolkit.modules.commands.domain
+
+import com.izivia.ocpi.toolkit.common.CiString
+import com.izivia.ocpi.toolkit.modules.tokens.domain.Token
+
+/**
+ * @property responseUrl (max-length=255) URL that the CommandResult POST should be sent to. This URL might contain a
+ * unique ID to be able to distinguish between StartSession requests.
+ *
+ * @property token Token object the Charge Point has to use to start a new session. The Token provided in this request
+ * is authorized by the eMSP.
+ *
+ * @property locationId (max-length=36) Location.id of the Location (belonging to the CPO this request is sent to) on
+ * which a session is to be started.
+ *
+ * @property evseUid (max-length=36) Optional EVSE.uid of the EVSE of this Location on which a session is to be started.
+ * Required when connector_id is set.
+ *
+ * @property connectorId (max-length=36) Optional Connector.id of the Connector of the EVSE on which a session is to be
+ * started. This field is required when the capability: START_SESSION_CONNECTOR_REQUIRED is set on the EVSE.
+ *
+ * @property authorizationReference (max-length=36) Reference to the authorization given by the eMSP, when given, this
+ * reference will be provided in the relevant Session and/or CDR.
+ */
+data class StartSession(
+    val responseUrl: CiString,
+    val token: Token,
+    val locationId: CiString,
+    val evseUid: CiString?,
+    val connectorId: CiString?,
+    val authorizationReference: CiString?,
+)

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/StartSession.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/StartSession.kt
@@ -28,5 +28,5 @@ data class StartSession(
     val locationId: CiString,
     val evseUid: CiString?,
     val connectorId: CiString?,
-    val authorizationReference: CiString?,
+    val authorizationReference: CiString?
 )

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/StopSession.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/StopSession.kt
@@ -1,0 +1,14 @@
+package com.izivia.ocpi.toolkit.modules.commands.domain
+
+import com.izivia.ocpi.toolkit.common.CiString
+
+/**
+ * @property responseUrl (max-length-255) URL that the CommandResult POST should be sent to. This URL might contain a
+ * unique ID to be able to distinguish between StopSession requests.
+ *
+ * @property sessionId (max-length-36) Session.id of the Session that is requested to be stopped.
+ */
+data class StopSession(
+    val responseUrl: CiString,
+    val sessionId: CiString,
+)

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/StopSession.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/StopSession.kt
@@ -10,5 +10,5 @@ import com.izivia.ocpi.toolkit.common.CiString
  */
 data class StopSession(
     val responseUrl: CiString,
-    val sessionId: CiString,
+    val sessionId: CiString
 )

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/UnlockConnector.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/UnlockConnector.kt
@@ -1,0 +1,23 @@
+package com.izivia.ocpi.toolkit.modules.commands.domain
+
+import com.izivia.ocpi.toolkit.common.CiString
+
+/**
+ * @property responseUrl (max-length=255) URL that the CommandResult POST should be sent to. This URL might contain a
+ * unique ID to be able to distinguish between UnlockConnector requests.
+ *
+ * @property locationId (max-length=36) Location.id of the Location (belonging to the CPO this request is sent to) of
+ * which it is requested to unlock the connector.
+ *
+ * @property evseUid (max-length=36) EVSE.uid of the EVSE of this Location of which it is requested to unlock the
+ * connector.
+ *
+ * @property connectorId (max-length=36) Connector.id of the Connector of this Location of which it is requested to
+ * unlock.
+ */
+data class UnlockConnector(
+    val responseUrl: CiString,
+    val locationId: CiString,
+    val evseUid: CiString,
+    val connectorId: CiString,
+)

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/UnlockConnector.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/UnlockConnector.kt
@@ -19,5 +19,5 @@ data class UnlockConnector(
     val responseUrl: CiString,
     val locationId: CiString,
     val evseUid: CiString,
-    val connectorId: CiString,
+    val connectorId: CiString
 )


### PR DESCRIPTION
Implementor is responsible for async handling of calling callback via the client

Example implementation of postStartSession
```
    override suspend fun postStartSession(
        partnerUrl: String,
        startSession: StartSession,
    ): OcpiResponseBody<CommandResponse> {
        validate {
            validateLength("response_url", startSession.responseUrl, 255)
            validateLength("token.country_code", startSession.token.countryCode, 2)
            validateLength("token.partyId", startSession.token.partyId, 3)
            validateLength("token.uid", startSession.token.uid, 36)
            validateLength("token.issuer", startSession.token.issuer, 64)
            validateLength("location_id", startSession.locationId, 36)
        }

        val responseType = if (startSession.evseUid == null) {
            // we don't allow remote start on a location. This is an implementation detail on our side
            log.warn("remote start session without evse_id from {}", partnerUrl)
            CommandResponseType.REJECTED
        } else {
            // you either need to store or forward the remote start reference, as we will need it in the session object. 
           async {
                val resultType = ocppClient.remoteStart(startSession.evseUid!!, startSession.token.uid)
                val result = CommandResult(resultType, emptyList())
                commandCpoClient.postCommandCallback(
                    result,
                    partnerUrl,
                    startSession.responseUrl
                )
            }

            CommandResponseType.ACCEPTED
        }

        return OcpiResponseBody.success(CommandResponse(responseType, 30, emptyList()))
    }
```