### PR TITLE
fix(transport) #87: Throw explicit exception when a required header is missing

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -54,8 +54,10 @@ inline fun <reified T> HttpResponse.parsePaginatedBody(offset: Int): OcpiRespons
         .let { parsedBody ->
             OcpiResponseBody(
                 data = parsedBody.data?.toSearchResult(
-                    totalCount = getHeader(Header.X_TOTAL_COUNT)!!.toInt(),
-                    limit = getHeader(Header.X_LIMIT)!!.toInt(),
+                    totalCount = getHeader(Header.X_TOTAL_COUNT)?.toInt()
+                        ?: throw OcpiToolkitMissingRequiredResponseHeaderException(Header.X_TOTAL_COUNT),
+                    limit = getHeader(Header.X_LIMIT)?.toInt()
+                        ?: throw OcpiToolkitMissingRequiredResponseHeaderException(Header.X_LIMIT),
                     offset = offset,
                     nextPageUrl = getHeader(Header.LINK)?.split("<")?.get(1)?.split(">")?.first()
                 ),

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiToolkitExceptions.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiToolkitExceptions.kt
@@ -16,3 +16,9 @@ class OcpiToolkitResponseParsingException(
 ) : Exception(
     "Response cannot be parsed. URL='$urlCalled', error='${cause.message}'"
 )
+
+class OcpiToolkitMissingRequiredResponseHeaderException(
+    header: String
+) : Exception(
+    """Required header "$header" not found in the response from the server"""
+)


### PR DESCRIPTION
Closes #87 