### PR TITLE
fix(transport) #91: Avoid throwing IndexOutOfBoundsException when Link header is missing content

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -59,7 +59,7 @@ inline fun <reified T> HttpResponse.parsePaginatedBody(offset: Int): OcpiRespons
                     limit = getHeader(Header.X_LIMIT)?.toInt()
                         ?: throw OcpiToolkitMissingRequiredResponseHeaderException(Header.X_LIMIT),
                     offset = offset,
-                    nextPageUrl = getHeader(Header.LINK)?.split("<")?.get(1)?.split(">")?.first()
+                    nextPageUrl = getHeader(Header.LINK)?.split("<")?.elementAtOrNull(1)?.split(">")?.first()
                 ),
                 status_code = parsedBody.status_code,
                 status_message = parsedBody.status_message,


### PR DESCRIPTION
Fixes #91