### PR TITLE
fix(common): Successful DELETE requests should return HTTP 200

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -347,6 +347,19 @@ suspend fun PartnerRepository.checkToken(
     val validToken = (allowTokenA && isCredentialsTokenAValid(token)) ||
         isCredentialsServerTokenValid(token)
 
+    // 7. Credentials module
+    // 7.2.3. PUT Method
+    // This method MUST return a HTTP status code 405: method not allowed if the client has not been registered yet
+    // 7.2.4. DELETE Method
+    // This method MUST return a HTTP status code 405: method not allowed if the client has not been registered before.
+    if (!validToken && httpRequest.path.contains("credentials") && httpRequest.method in listOf(
+            HttpMethod.PUT,
+            HttpMethod.DELETE
+        )
+    ) {
+        throw HttpException(HttpStatus.METHOD_NOT_ALLOWED, "Method not allowed")
+    }
+
     if (!validToken) {
         throw HttpException(HttpStatus.UNAUTHORIZED, "Invalid server token (token A allowed: $allowTokenA)")
     }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -340,9 +340,9 @@ suspend fun PartnerRepository.checkToken(
      * So, we allow token A only if we are in this case.
      */
 
-    val allowTokenA = httpRequest.path.contains("versions") ||
+    val allowTokenA = httpRequest.path.contains(ModuleID.versions.name) ||
         httpRequest.path.contains("/{versionNumber}") ||
-        httpRequest.path.contains("credentials")
+        httpRequest.path.contains(ModuleID.credentials.name)
 
     val validToken = (allowTokenA && isCredentialsTokenAValid(token)) ||
         isCredentialsServerTokenValid(token)
@@ -352,7 +352,7 @@ suspend fun PartnerRepository.checkToken(
     // This method MUST return a HTTP status code 405: method not allowed if the client has not been registered yet
     // 7.2.4. DELETE Method
     // This method MUST return a HTTP status code 405: method not allowed if the client has not been registered before.
-    if (!validToken && httpRequest.path.contains("credentials") && httpRequest.method in listOf(
+    if (!validToken && httpRequest.path.contains(ModuleID.credentials.name) && httpRequest.method in listOf(
             HttpMethod.PUT,
             HttpMethod.DELETE
         )

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiExceptions.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiExceptions.kt
@@ -44,6 +44,12 @@ class OcpiClientUnknownTokenException(
     override val ocpiStatus: OcpiStatus = OcpiStatus.CLIENT_UNKNOWN_TOKEN
 ) : OcpiException(message, httpStatus, ocpiStatus)
 
+class OcpiClientMethodNotAllowedException(
+    message: String = "Method not allowed",
+    override val httpStatus: HttpStatus = HttpStatus.METHOD_NOT_ALLOWED,
+    override val ocpiStatus: OcpiStatus = OcpiStatus.CLIENT_UNKNOWN_TOKEN
+) : OcpiException(message, httpStatus, ocpiStatus)
+
 // 3xxx: Server errors
 class OcpiServerGenericException(
     message: String,

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiResponseBody.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiResponseBody.kt
@@ -3,10 +3,7 @@ package com.izivia.ocpi.toolkit.common
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.izivia.ocpi.toolkit.common.context.currentResponseMessageRoutingHeadersOrNull
 import com.izivia.ocpi.toolkit.common.validation.toReadableString
-import com.izivia.ocpi.toolkit.transport.domain.HttpException
-import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
-import com.izivia.ocpi.toolkit.transport.domain.HttpResponse
-import com.izivia.ocpi.toolkit.transport.domain.HttpStatus
+import com.izivia.ocpi.toolkit.transport.domain.*
 import org.apache.logging.log4j.LogManager
 import org.valiktor.ConstraintViolationException
 import java.time.Instant
@@ -122,7 +119,12 @@ suspend fun <T> HttpRequest.httpResponse(fn: suspend () -> OcpiResponseBody<T>):
 
         HttpResponse(
             status = when (ocpiResponseBody.statusCode) {
-                OcpiStatus.SUCCESS.code -> if (ocpiResponseBody.data != null) HttpStatus.OK else HttpStatus.NOT_FOUND
+                OcpiStatus.SUCCESS.code ->
+                    if (this.method == HttpMethod.DELETE || ocpiResponseBody.data != null) {
+                        HttpStatus.OK
+                    } else {
+                        HttpStatus.NOT_FOUND
+                    }
                 OcpiStatus.CLIENT_INVALID_PARAMETERS.code -> HttpStatus.BAD_REQUEST
                 else -> HttpStatus.OK
             },

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
@@ -76,7 +76,9 @@ open class CredentialsServerService(
         debugHeaders: Map<String, String>
     ): OcpiResponseBody<Credentials> = OcpiResponseBody.of {
         val partnerUrl = partnerRepository.getPartnerUrlByCredentialsServerToken(token)
-            ?: throw OcpiClientInvalidParametersException("Invalid server token ($token)")
+            // This line should not be reached when using the HttpUtils.kt PartnerRepository.checkToken
+            // implementation of the toolkit, but is included for custom implementations.
+            ?: throw OcpiClientMethodNotAllowedException()
 
         // Save credentials roles of partner
         partnerRepository.saveCredentialsRoles(
@@ -113,7 +115,9 @@ open class CredentialsServerService(
                 // to the system.
                 partnerRepository.invalidateCredentialsClientToken(partnerUrl = partnerUrl)
             }
-            ?: throw OcpiClientInvalidParametersException("Invalid server token ($token)")
+            // This line should not be reached when using the HttpUtils.kt PartnerRepository.checkToken
+            // implementation of the toolkit, but is included for custom implementations.
+            ?: throw OcpiClientMethodNotAllowedException()
 
         null
     }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/domain/ModuleID.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/domain/ModuleID.kt
@@ -26,5 +26,7 @@ enum class ModuleID {
 
     tariffs,
 
-    tokens
+    tokens,
+
+    versions
 }


### PR DESCRIPTION
Closes #11 

I think this is a good solution because the result of DELETE requests will usually be empty.

By mistake, but I've pushed a related change that closes #104 