### PR TITLE
feat(locations) #130: Skip null values in Connector.tariffIds

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/domain/Connector.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/domain/Connector.kt
@@ -1,5 +1,7 @@
 package com.izivia.ocpi.toolkit.modules.locations.domain
 
+import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.annotation.Nulls
 import com.izivia.ocpi.toolkit.annotations.Partial
 import com.izivia.ocpi.toolkit.common.CiString
 import java.time.Instant
@@ -36,6 +38,7 @@ data class Connector(
     val maxVoltage: Int,
     val maxAmperage: Int,
     val maxElectricPower: Int? = null,
+    @JsonSetter(contentNulls = Nulls.SKIP)
     val tariffIds: List<CiString>? = null,
     val termsAndConditions: String? = null,
     val lastUpdated: Instant


### PR DESCRIPTION
Closes #130