### PR TITLE
feat: rename partnerUrl parameter to partnerId in search method to allow the usage of another field as identifier

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiClientUtils.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiClientUtils.kt
@@ -7,7 +7,7 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 
 suspend inline fun <reified T> getNextPage(
     transportClientBuilder: TransportClientBuilder,
-    serverVersionsEndpointUrl: String,
+    partnerId: String,
     partnerRepository: PartnerRepository,
     previousResponse: OcpiResponseBody<SearchResult<T>>
 ): OcpiResponseBody<SearchResult<T>>? =
@@ -21,7 +21,7 @@ suspend inline fun <reified T> getNextPage(
                         requestId = generateRequestId(),
                         correlationId = generateCorrelationId()
                     )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             )
                 .parsePaginatedBody(previousResponse.data.offset)
         }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/cdr/CdrsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/cdr/CdrsCpoClient.kt
@@ -12,18 +12,18 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 /**
  * Sends calls to an eMSP server
  * @property transportClientBuilder used to build transport client
- * @property serverVersionsEndpointUrl used to know which partner to communicate with
+ * @property partnerId used to know which partner to communicate with
  * @property partnerRepository used to get information about the partner (endpoint, token)
  */
 class CdrsCpoClient(
     private val transportClientBuilder: TransportClientBuilder,
-    private val serverVersionsEndpointUrl: String,
+    private val partnerId: String,
     private val partnerRepository: PartnerRepository
 ) : CdrsEmspInterface<URL> {
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.cdrs,
-            partnerUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             partnerRepository = partnerRepository
         )
 
@@ -37,7 +37,7 @@ class CdrsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             )
                 .parseBody()
         }
@@ -52,7 +52,7 @@ class CdrsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             )
                 .parseBody()
         }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/cdr/CdrsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/cdr/CdrsEmspClient.kt
@@ -12,13 +12,13 @@ import java.time.Instant
 
 class CdrsEmspClient(
     private val transportClientBuilder: TransportClientBuilder,
-    private val serverVersionsEndpointUrl: String,
+    private val partnerId: String,
     private val partnerRepository: PartnerRepository
 ) : CdrsCpoInterface {
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.cdrs,
-            partnerUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             partnerRepository = partnerRepository
         )
 
@@ -42,7 +42,7 @@ class CdrsEmspClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             )
                 .parsePaginatedBody(offset)
         }
@@ -51,7 +51,7 @@ class CdrsEmspClient(
         previousResponse: OcpiResponseBody<SearchResult<Cdr>>
     ): OcpiResponseBody<SearchResult<Cdr>>? = getNextPage(
         transportClientBuilder = transportClientBuilder,
-        serverVersionsEndpointUrl = serverVersionsEndpointUrl,
+        partnerId = partnerId,
         partnerRepository = partnerRepository,
         previousResponse = previousResponse
     )

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/chargingProfiles/ChargingProfilesCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/chargingProfiles/ChargingProfilesCpoClient.kt
@@ -18,13 +18,13 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpStatus
  * Send calls to the SCSP
  *
  * @property transportClientBuilder used to build transport client
- * @property serverVersionsEndpointUrl used to know which partner to communicate with
+ * @property partnerId used to know which partner to communicate with
  * @property partnerRepository used to get information about the partner (endpoint, token)
  * @property callbackBaseUrl used to build the callback URL sent to the other partner
  */
 class ChargingProfilesCpoClient(
     private val transportClientBuilder: TransportClientBuilder,
-    private val serverVersionsEndpointUrl: String,
+    private val partnerId: String,
     private val partnerRepository: PartnerRepository,
     private val callbackBaseUrl: String
 ) {
@@ -35,7 +35,7 @@ class ChargingProfilesCpoClient(
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.chargingprofiles,
-            partnerUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             partnerRepository = partnerRepository
         )
 
@@ -53,7 +53,7 @@ class ChargingProfilesCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .also {
                 if (it.status != HttpStatus.OK) throw HttpException(it.status, "status should be ${HttpStatus.OK}")
@@ -75,7 +75,7 @@ class ChargingProfilesCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .also {
                 if (it.status != HttpStatus.OK) throw HttpException(it.status, "status should be ${HttpStatus.OK}")
@@ -97,7 +97,7 @@ class ChargingProfilesCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .also {
                 if (it.status != HttpStatus.OK) throw HttpException(it.status, "status should be ${HttpStatus.OK}")
@@ -119,7 +119,7 @@ class ChargingProfilesCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .also {
                 if (it.status != HttpStatus.OK) throw HttpException(it.status, "status should be ${HttpStatus.OK}")

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/chargingProfiles/ChargingProfilesScspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/chargingProfiles/ChargingProfilesScspClient.kt
@@ -15,7 +15,7 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpStatus
 
 class ChargingProfilesScspClient(
     private val transportClientBuilder: TransportClientBuilder,
-    private val serverVersionsEndpointUrl: String,
+    private val partnerId: String,
     private val partnerRepository: PartnerRepository,
     private val callbackBaseUrl: URL
 ) {
@@ -23,7 +23,7 @@ class ChargingProfilesScspClient(
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.chargingprofiles,
-            partnerUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             partnerRepository = partnerRepository
         )
 
@@ -46,7 +46,7 @@ class ChargingProfilesScspClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .also {
                 if (it.status != HttpStatus.OK) throw HttpException(it.status, "status should be ${HttpStatus.OK}")
@@ -75,7 +75,7 @@ class ChargingProfilesScspClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .also {
                 if (it.status != HttpStatus.OK && it.status != HttpStatus.CREATED) {
@@ -102,7 +102,7 @@ class ChargingProfilesScspClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .also {
                 if (it.status != HttpStatus.OK) throw HttpException(it.status, "status should be ${HttpStatus.OK}")

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoClient.kt
@@ -13,7 +13,7 @@ class CommandCpoClient(
 ) {
     suspend fun postCommandCallback(
         commandResult: CommandResult,
-        partnerUrl: String,
+        partnerId: String,
         responseUrl: String
     ): OcpiResponseBody<Any> =
         transportClientBuilder
@@ -28,6 +28,6 @@ class CommandCpoClient(
                         requestId = generateUUIDv4Token(),
                         correlationId = generateUUIDv4Token()
                     )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = partnerUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             ).parseBody()
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspClient.kt
@@ -13,7 +13,7 @@ import java.time.Instant
 
 class CommandEmspClient(
     private val transportClientBuilder: TransportClientBuilder,
-    private val serverVersionsEndpointUrl: String,
+    private val partnerId: String,
     private val partnerRepository: PartnerRepository,
     private val callbackBaseUrl: String
 ) {
@@ -21,7 +21,7 @@ class CommandEmspClient(
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.commands,
-            partnerUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             partnerRepository = partnerRepository
         )
 
@@ -52,7 +52,7 @@ class CommandEmspClient(
                         requestId = generateUUIDv4Token(),
                         correlationId = generateUUIDv4Token()
                     )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             )
                 .parseBody()
         }
@@ -74,7 +74,7 @@ class CommandEmspClient(
                         requestId = generateUUIDv4Token(),
                         correlationId = generateUUIDv4Token()
                     )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             )
                 .parseBody()
         }
@@ -108,7 +108,7 @@ class CommandEmspClient(
                         requestId = generateUUIDv4Token(),
                         correlationId = generateUUIDv4Token()
                     )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             )
                 .parseBody()
         }
@@ -130,7 +130,7 @@ class CommandEmspClient(
                         requestId = generateUUIDv4Token(),
                         correlationId = generateUUIDv4Token()
                     )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             )
                 .parseBody()
         }
@@ -159,7 +159,7 @@ class CommandEmspClient(
                         requestId = generateUUIDv4Token(),
                         correlationId = generateUUIDv4Token()
                     )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             )
                 .parseBody()
         }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PartnerRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PartnerRepository.kt
@@ -62,6 +62,14 @@ interface PartnerRepository {
     suspend fun isCredentialsServerTokenValid(credentialsServerToken: String): Boolean
 
     /**
+     * Used to find a partner url by its identifier.
+     *
+     * @param partnerId, identifies uniquely the partner
+     * @return the partner url
+     */
+    suspend fun getPartnerUrl(partnerId: String): String?
+
+    /**
      * Used to find a partner url by its server token. Basically used to retrieve all the partner information
      * from the token in a request.
      *

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PartnerRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/repositories/PartnerRepository.kt
@@ -25,23 +25,23 @@ interface PartnerRepository {
 
     /**
      * When calling a partner, the http client has to be authenticated. This method is called to retrieve the
-     * token A for a given partner identified by its /versions url.
+     * token A for a given partner identified by an id value.
      *
      * The token A is only used during registration process.
      *
-     * @param partnerUrl the partner, identified by its /versions url
+     * @param partnerId, identifies uniquely the partner
      * @return the token A, if found, null otherwise
      */
-    suspend fun getCredentialsTokenA(partnerUrl: String): String?
+    suspend fun getCredentialsTokenA(partnerId: String): String?
 
     /**
      * When calling a partner, the http client has to be authenticated. This method is called to retrieve the
-     * client token for a given partner identified by its /versions url.
+     * client token for a given partner identified by an id value.
      *
-     * @param partnerUrl the partner, identified by its /versions url
+     * @param partnerId, identifies uniquely the partner
      * @return the client token, if found, null otherwise
      */
-    suspend fun getCredentialsClientToken(partnerUrl: String): String?
+    suspend fun getCredentialsClientToken(partnerId: String): String?
 
     /**
      * A partner has to use its server token to communicate with us. On first registration, the token used is the token
@@ -71,20 +71,38 @@ interface PartnerRepository {
     suspend fun getPartnerUrlByCredentialsServerToken(credentialsServerToken: String): String?
 
     /**
-     * Used to get available endpoints for a given partner identified by its url (partnerUrl)
+     * Used to find a partner id by its server token. Basically used to retrieve all the partner information
+     * from the token in a request.
      *
-     * @param partnerUrl the partner, identified by its /versions url
-     * @return the list of available endpoints for the given partner
+     * @param credentialsServerToken the server token, the one partners use to communicate
+     * @return the partner id
      */
-    suspend fun getEndpoints(partnerUrl: String): List<Endpoint>
+    suspend fun getPartnerIdByCredentialsServerToken(credentialsServerToken: String): String?
 
     /**
-     * Used to get used version for a given partner identified by its url (partnerUrl)
+     * Used to find a partner id by its token A. Basically used to retrieve all the partner information
+     * from the token in a request.
      *
-     * @param partnerUrl the partner, identified by its /versions url
+     * @param credentialsTokenA the token of a partner
+     * @return the partner id
+     */
+    suspend fun getPartnerIdByCredentialsTokenA(credentialsTokenA: String): String?
+
+    /**
+     * Used to get available endpoints for a given partner identified by an id value.
+     *
+     * @param partnerId, identifies uniquely the partner
+     * @return the list of available endpoints for the given partner
+     */
+    suspend fun getEndpoints(partnerId: String): List<Endpoint>
+
+    /**
+     * Used to get used version for a given partner identified by an id value.
+     *
+     * @param partnerId, identifies uniquely the partner
      * @return the currently used version for the given partner or null
      */
-    suspend fun getVersion(partnerUrl: String): Version?
+    suspend fun getVersion(partnerId: String): Version?
 
     /**
      * This is the first function to be called on registration. So that later on we can use partner url as an
@@ -101,46 +119,46 @@ interface PartnerRepository {
     /**
      * Used to save credentials roles given by a partner during registration.
      *
-     * @param partnerUrl the partner, identified by its /versions url
+     * @param partnerId, identifies uniquely the partner
      * @param credentialsRoles
      * @return the updated credentials roles
      */
-    suspend fun saveCredentialsRoles(partnerUrl: String, credentialsRoles: List<CredentialRole>): List<CredentialRole>
+    suspend fun saveCredentialsRoles(partnerId: String, credentialsRoles: List<CredentialRole>): List<CredentialRole>
 
     /**
-     * Used to save available version for a given partner identified by its url (partnerUrl)
+     * Used to save available version for a given partner identified by an id value.
      *
-     * @param partnerUrl the partner, identified by its /versions url
+     * @param partnerId, identifies uniquely the partner
      * @param version Version
      * @return the updated version
      */
-    suspend fun saveVersion(partnerUrl: String, version: Version): Version
+    suspend fun saveVersion(partnerId: String, version: Version): Version
 
     /**
-     * Used to save endpoints for a given partner identified by its url (partnerUrl)
+     * Used to save endpoints for a given partner identified by an id value.
      *
-     * @param partnerUrl the partner, identified by its /versions url
+     * @param partnerId, identifies uniquely the partner
      * @param endpoints List<Endpoint>
      * @return List<Endpoint> the updated list of endpoints
      */
-    suspend fun saveEndpoints(partnerUrl: String, endpoints: List<Endpoint>): List<Endpoint>
+    suspend fun saveEndpoints(partnerId: String, endpoints: List<Endpoint>): List<Endpoint>
 
     /**
-     * Called to save the client token for a given partner identified by its url (partnerUrl).
+     * Called to save the client token for a given partner identified by an id value..
      *
      * This token is the one that will be used to communicate with the partner.
      * For context in OCPI, on registration, this token is:
      * - if you are the receiver: token B
      * - if you are the sender: token C
      *
-     * @param partnerUrl the partner, identified by its /versions url
+     * @param partnerId, identifies uniquely the partner
      * @param credentialsClientToken String
      * @return the credentialsClientToken
      */
-    suspend fun saveCredentialsClientToken(partnerUrl: String, credentialsClientToken: String): String
+    suspend fun saveCredentialsClientToken(partnerId: String, credentialsClientToken: String): String
 
     /**
-     * Called to save the server token for a given partner identified by its url (partnerUrl).
+     * Called to save the server token for a given partner identified by an id value.
      *
      * This token is the one that the partner will use to communicate. So it is this token that has to be used to check
      * if requests are properly authenticated.
@@ -149,31 +167,31 @@ interface PartnerRepository {
      * - if you are the receiver: token C
      * - if you are the sender: token B
      *
-     * @param partnerUrl the partner, identified by its /versions url
+     * @param partnerId identifies uniquely the partner
      * @param credentialsServerToken String
      * @return the credentialsServerToken
      */
-    suspend fun saveCredentialsServerToken(partnerUrl: String, credentialsServerToken: String): String
+    suspend fun saveCredentialsServerToken(partnerId: String, credentialsServerToken: String): String
 
     /**
-     * Called once registration is done for a given partner identified by its url (partnerUrl).
+     * Called once registration is done for a given partner identified by an id value..
      *
      * The token A has to be invalidated.
      *
-     * @param partnerUrl the partner, identified by its /versions url
+     * @param partnerId, identifies uniquely the partner
      * @return true if it was a success, false otherwise
      */
-    suspend fun invalidateCredentialsTokenA(partnerUrl: String): Boolean
+    suspend fun invalidateCredentialsTokenA(partnerId: String): Boolean
 
     /**
      * Called when a partner asks to unregister itself.
      *
      * It has to invalidate **ONLY clientToken**. ServerToken must stay valid because the partner can still use it.
      *
-     * @param partnerUrl the partner, identified by its /versions url
+     * @param partnerId, identifies uniquely the partner
      * @return true if it was a success, false otherwise
      */
-    suspend fun invalidateCredentialsClientToken(partnerUrl: String): Boolean
+    suspend fun invalidateCredentialsClientToken(partnerId: String): Boolean
 
     /**
      * Called when your system unregisters from a partner.
@@ -181,8 +199,8 @@ interface PartnerRepository {
      * It has to invalidate **ONLY serverToken**. ClientToken must stay valid because your system can still use it
      * to communicate with the partner.
      *
-     * @param partnerUrl the partner, identified by its /versions url
+     * @param partnerId, identifies uniquely the partner
      * @return true if it was a success, false otherwise
      */
-    suspend fun invalidateCredentialsServerToken(partnerUrl: String): Boolean
+    suspend fun invalidateCredentialsServerToken(partnerId: String): Boolean
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsClientService.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsClientService.kt
@@ -27,6 +27,7 @@ import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
  * @property clientVersionsRepository client's repository to retrieve available versions on the client
  * @property clientCredentialsRoleRepository client's repository to retrieve its role
  * @property serverVersionsEndpointUrl the versions endpoint url of the server (for the client to retrieve endpoints)
+ * @property partnerId a value that identifies uniquely the partner
  * @property transportClientBuilder used to build a transport (will be used to create CredentialClient to make calls)
  * @property requiredEndpoints the endpoints this client expects from the other part to provide
  */
@@ -36,18 +37,19 @@ open class CredentialsClientService(
     private val clientVersionsRepository: VersionsRepository,
     private val clientCredentialsRoleRepository: CredentialsRoleRepository,
     private val serverVersionsEndpointUrl: String,
+    private val partnerId: String,
     private val transportClientBuilder: TransportClientBuilder,
     private val requiredEndpoints: RequiredEndpoints?
 ) {
     suspend fun get(): Credentials = clientPartnerRepository
-        .getCredentialsClientToken(partnerUrl = serverVersionsEndpointUrl)
+        .getCredentialsClientToken(partnerId = partnerId)
         ?.let { clientToken ->
             buildCredentialClient()
                 .get(token = clientToken)
                 .let { it.data ?: throw OcpiResponseException(it.statusCode, it.statusMessage ?: "unknown") }
         }
         ?: throw OcpiClientGenericException(
-            "Could not find CREDENTIALS_TOKEN_C associated with partner $serverVersionsEndpointUrl"
+            "Could not find CREDENTIALS_TOKEN_C associated with partner $partnerId"
         )
 
     /**
@@ -78,10 +80,10 @@ open class CredentialsClientService(
     suspend fun register(): Credentials {
         // Get token provided by receiver outside the OCPI protocol (for example by an admin)
         val credentialsTokenA =
-            clientPartnerRepository.getCredentialsClientToken(partnerUrl = serverVersionsEndpointUrl)
-                ?: clientPartnerRepository.getCredentialsTokenA(partnerUrl = serverVersionsEndpointUrl)
+            clientPartnerRepository.getCredentialsClientToken(partnerId = partnerId)
+                ?: clientPartnerRepository.getCredentialsTokenA(partnerId = partnerId)
                 ?: throw OcpiClientInvalidParametersException(
-                    "Could not find the TokenA or the ClientToken associated with partner $serverVersionsEndpointUrl"
+                    "Could not find the TokenA or the ClientToken associated with partner $partnerId"
                 )
 
         findLatestMutualVersionAndSaveInformation()
@@ -89,7 +91,7 @@ open class CredentialsClientService(
         // Generate token B,  which is the server token in this case because we are the sender. It's this token
         // that the receiver will use to contact us.
         val serverToken = clientPartnerRepository.saveCredentialsServerToken(
-            partnerUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             credentialsServerToken = generateUUIDv4Token()
         )
 
@@ -108,19 +110,19 @@ open class CredentialsClientService(
 
         // Save credentials roles of partner
         clientPartnerRepository.saveCredentialsRoles(
-            partnerUrl = credentials.url,
+            partnerId = partnerId,
             credentialsRoles = credentials.roles
         )
 
         // Store token C, which is the client token in this case because we are the sender. It's this one that
         // we will use to communicate with the receiver
         clientPartnerRepository.saveCredentialsClientToken(
-            partnerUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             credentialsClientToken = credentials.token
         )
 
         // Remove token A because it is useless from now on
-        clientPartnerRepository.invalidateCredentialsTokenA(partnerUrl = serverVersionsEndpointUrl)
+        clientPartnerRepository.invalidateCredentialsTokenA(partnerId = partnerId)
 
         return credentials
     }
@@ -128,9 +130,9 @@ open class CredentialsClientService(
     suspend fun update(): Credentials {
         // Token to communicate with receiver
         val credentialsClientToken =
-            clientPartnerRepository.getCredentialsClientToken(partnerUrl = serverVersionsEndpointUrl)
+            clientPartnerRepository.getCredentialsClientToken(partnerId = partnerId)
                 ?: throw OcpiClientInvalidParametersException(
-                    "Could not find the ClientToken associated with partner $serverVersionsEndpointUrl"
+                    "Could not find the ClientToken associated with partner $partnerId"
                 )
 
         findLatestMutualVersionAndSaveInformation()
@@ -138,7 +140,7 @@ open class CredentialsClientService(
         // Generate token B, which is the server token, because it's the one that will be used by the partner (receiver)
         // to communicate with us
         val credentialsServerToken = clientPartnerRepository.saveCredentialsServerToken(
-            partnerUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             credentialsServerToken = generateUUIDv4Token()
         )
 
@@ -157,14 +159,14 @@ open class CredentialsClientService(
 
         // Save credentials roles of partner
         clientPartnerRepository.saveCredentialsRoles(
-            partnerUrl = credentials.url,
+            partnerId = partnerId,
             credentialsRoles = credentials.roles
         )
 
         // Store token C, which is the client token in this case because we are the sender. It's this one that
         // we will use to communicate with the receiver
         clientPartnerRepository.saveCredentialsClientToken(
-            partnerUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             credentialsClientToken = credentials.token
         )
 
@@ -172,14 +174,14 @@ open class CredentialsClientService(
     }
 
     suspend fun delete() = clientPartnerRepository
-        .getCredentialsClientToken(partnerUrl = serverVersionsEndpointUrl)
+        .getCredentialsClientToken(partnerId = partnerId)
         ?.let { clientToken ->
             buildCredentialClient()
                 .delete(token = clientToken)
                 .also {
                     // Only server token is invalidated. It means that the system can still send authenticated requests
                     // to the partner
-                    clientPartnerRepository.invalidateCredentialsServerToken(partnerUrl = serverVersionsEndpointUrl)
+                    clientPartnerRepository.invalidateCredentialsServerToken(partnerId = partnerId)
                 }
                 .also {
                     if (it.statusCode != OcpiStatus.SUCCESS.code) {
@@ -188,13 +190,14 @@ open class CredentialsClientService(
                 }
         }
         ?: throw OcpiClientGenericException(
-            "Could not find client token associated with partner $serverVersionsEndpointUrl"
+            "Could not find client token associated with partner $partnerId"
         )
 
     private suspend fun findLatestMutualVersionAndSaveInformation(): List<Endpoint> {
         val availableServerVersions = VersionsClient(
             transportClientBuilder = transportClientBuilder,
             serverVersionsEndpointUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             partnerRepository = clientPartnerRepository
         )
             .getVersions()
@@ -211,16 +214,16 @@ open class CredentialsClientService(
                     .any { clientVersionNumber -> serverVersion.version == clientVersionNumber.value }
             }
             ?: throw OcpiServerUnsupportedVersionException(
-                "Could not find mutual version with partner $serverVersionsEndpointUrl"
+                "Could not find mutual version with partner $partnerId"
             )
 
         // Store version that will be used
-        clientPartnerRepository.saveVersion(partnerUrl = serverVersionsEndpointUrl, version = latestMutualVersion)
+        clientPartnerRepository.saveVersion(partnerId = partnerId, version = latestMutualVersion)
 
         // Get available endpoints for a given version
         val versionDetails = VersionDetailsClient(
             transportClientBuilder = transportClientBuilder,
-            serverVersionsEndpointUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             partnerRepository = clientPartnerRepository
         )
             .getVersionDetails()
@@ -232,13 +235,13 @@ open class CredentialsClientService(
 
         // Store version & endpoint
         return clientPartnerRepository.saveEndpoints(
-            partnerUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             endpoints = versionDetails.endpoints
         )
     }
 
     private suspend fun getOrFindEndpoints(): List<Endpoint> = clientPartnerRepository
-        .getEndpoints(partnerUrl = serverVersionsEndpointUrl)
+        .getEndpoints(partnerId = partnerId)
         .takeIf { it.isNotEmpty() }
         ?: findLatestMutualVersionAndSaveInformation()
 
@@ -249,7 +252,7 @@ open class CredentialsClientService(
                     .find { it.identifier == ModuleID.credentials }
                     ?.url
                     ?: throw OcpiServerUnsupportedVersionException(
-                        "No credentials endpoint for $serverVersionsEndpointUrl"
+                        "No credentials endpoint for $partnerId"
                     )
             )
     )

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsClientService.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsClientService.kt
@@ -26,7 +26,6 @@ import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
  * @property clientPartnerRepository client's repository to store and retrieve tokens and information about partners
  * @property clientVersionsRepository client's repository to retrieve available versions on the client
  * @property clientCredentialsRoleRepository client's repository to retrieve its role
- * @property serverVersionsEndpointUrl the versions endpoint url of the server (for the client to retrieve endpoints)
  * @property partnerId a value that identifies uniquely the partner
  * @property transportClientBuilder used to build a transport (will be used to create CredentialClient to make calls)
  * @property requiredEndpoints the endpoints this client expects from the other part to provide
@@ -36,7 +35,6 @@ open class CredentialsClientService(
     private val clientPartnerRepository: PartnerRepository,
     private val clientVersionsRepository: VersionsRepository,
     private val clientCredentialsRoleRepository: CredentialsRoleRepository,
-    private val serverVersionsEndpointUrl: String,
     private val partnerId: String,
     private val transportClientBuilder: TransportClientBuilder,
     private val requiredEndpoints: RequiredEndpoints?
@@ -196,7 +194,6 @@ open class CredentialsClientService(
     private suspend fun findLatestMutualVersionAndSaveInformation(): List<Endpoint> {
         val availableServerVersions = VersionsClient(
             transportClientBuilder = transportClientBuilder,
-            serverVersionsEndpointUrl = serverVersionsEndpointUrl,
             partnerId = partnerId,
             partnerRepository = clientPartnerRepository
         )

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
@@ -35,12 +35,6 @@ open class CredentialsServerService(
         // A partner can use a valid serverToken on registration.
         // It can happen when a partner unregister, then registers with its clientToken (which is the serverToken
         // for us)
-        partnerRepository.getPartnerUrlByCredentialsServerToken(token)
-            // If we could not find a partner with this serverToken, then, it means that it's probably a tokenA
-            ?: partnerRepository.savePartnerUrlForTokenA(tokenA = token, partnerUrl = credentials.url)
-            ?: throw OcpiClientInvalidParametersException(
-                "Invalid token ($token) - should be either a TokenA or a ServerToken"
-            )
         val partnerId = partnerRepository.getPartnerIdByCredentialsServerToken(token)
             // If we could not find a partner with this serverToken, then, it means that it's probably a tokenA
             ?: partnerRepository.getPartnerIdByCredentialsTokenA(credentialsTokenA = token)

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
@@ -12,19 +12,19 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 /**
  * Sends calls to an eMSP server
  * @property transportClientBuilder used to build transport client
- * @property serverVersionsEndpointUrl used to know which partner to communicate with
+ * @property partnerId used to know which partner to communicate with
  * @property partnerRepository used to get information about the partner (endpoint, token)
  */
 class LocationsCpoClient(
     private val transportClientBuilder: TransportClientBuilder,
-    private val serverVersionsEndpointUrl: String,
+    private val partnerId: String,
     private val partnerRepository: PartnerRepository
 ) : LocationsEmspInterface {
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.locations,
-            partnerUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             partnerRepository = partnerRepository
         )
 
@@ -42,7 +42,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .parseBody()
     }
@@ -62,7 +62,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .parseBody()
     }
@@ -83,7 +83,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .parseBody()
     }
@@ -104,7 +104,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .parseBody()
     }
@@ -126,7 +126,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .parseBody()
     }
@@ -149,7 +149,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .parseBody()
     }
@@ -170,7 +170,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .parseBody()
     }
@@ -192,7 +192,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .parseBody()
     }
@@ -215,7 +215,7 @@ class LocationsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .parseBody()
     }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
@@ -15,19 +15,19 @@ import java.time.Instant
 /**
  * Sends calls to the CPO
  * @property transportClientBuilder used to build transport client
- * @property serverVersionsEndpointUrl used to know which partner to communicate with
+ * @property partnerId used to know which partner to communicate with
  * @property partnerRepository used to get information about the partner (endpoint, token)
  */
 class LocationsEmspClient(
     private val transportClientBuilder: TransportClientBuilder,
-    private val serverVersionsEndpointUrl: String,
+    private val partnerId: String,
     private val partnerRepository: PartnerRepository
 ) : LocationsCpoInterface {
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.locations,
-            partnerUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             partnerRepository = partnerRepository
         )
 
@@ -51,7 +51,7 @@ class LocationsEmspClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .parsePaginatedBody(offset)
     }
@@ -60,7 +60,7 @@ class LocationsEmspClient(
         previousResponse: OcpiResponseBody<SearchResult<Location>>
     ): OcpiResponseBody<SearchResult<Location>>? = getNextPage(
         transportClientBuilder = transportClientBuilder,
-        serverVersionsEndpointUrl = serverVersionsEndpointUrl,
+        partnerId = partnerId,
         partnerRepository = partnerRepository,
         previousResponse = previousResponse
     )
@@ -75,7 +75,7 @@ class LocationsEmspClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .parseBody()
     }
@@ -91,7 +91,7 @@ class LocationsEmspClient(
                         requestId = generateRequestId(),
                         correlationId = generateCorrelationId()
                     )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             )
                 .parseBody()
         }
@@ -110,7 +110,7 @@ class LocationsEmspClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
         )
             .parseBody()
     }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsCpoClient.kt
@@ -13,18 +13,18 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 /**
  * Sends calls to an eMSP server
  * @property transportClientBuilder used to build transport client
- * @property serverVersionsEndpointUrl used to know which partner to communicate with
+ * @property partnerId used to know which partner to communicate with
  * @property partnerRepository used to get information about the partner (endpoint, token)
  */
 class SessionsCpoClient(
     private val transportClientBuilder: TransportClientBuilder,
-    private val serverVersionsEndpointUrl: String,
+    private val partnerId: String,
     private val partnerRepository: PartnerRepository
 ) : SessionsEmspInterface {
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.sessions,
-            partnerUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             partnerRepository = partnerRepository
         )
 
@@ -42,7 +42,7 @@ class SessionsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             )
                 .parseBody()
         }
@@ -63,7 +63,7 @@ class SessionsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             )
                 .parseBody()
         }
@@ -84,7 +84,7 @@ class SessionsCpoClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             )
                 .parseBody()
         }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsEmspClient.kt
@@ -15,18 +15,18 @@ import java.time.Instant
 /**
  * Sends calls to the CPO
  * @property transportClientBuilder used to build transport client
- * @property serverVersionsEndpointUrl used to know which partner to communicate with
+ * @property partnerId used to know which partner to communicate with
  * @property partnerRepository used to get information about the partner (endpoint, token)
  */
 class SessionsEmspClient(
     private val transportClientBuilder: TransportClientBuilder,
-    private val serverVersionsEndpointUrl: String,
+    private val partnerId: String,
     private val partnerRepository: PartnerRepository
 ) : SessionsCpoInterface {
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.sessions,
-            partnerUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             partnerRepository = partnerRepository
         )
 
@@ -50,7 +50,7 @@ class SessionsEmspClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             )
                 .parsePaginatedBody(offset)
         }
@@ -59,7 +59,7 @@ class SessionsEmspClient(
         previousResponse: OcpiResponseBody<SearchResult<Session>>
     ): OcpiResponseBody<SearchResult<Session>>? = getNextPage(
         transportClientBuilder = transportClientBuilder,
-        serverVersionsEndpointUrl = serverVersionsEndpointUrl,
+        partnerId = partnerId,
         partnerRepository = partnerRepository,
         previousResponse = previousResponse
     )
@@ -78,7 +78,7 @@ class SessionsEmspClient(
                     requestId = generateRequestId(),
                     correlationId = generateCorrelationId()
                 )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             )
                 .parseBody()
         }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
@@ -16,18 +16,18 @@ import java.time.Instant
 /**
  * Sends calls to an eMSP server
  * @property transportClientBuilder used to build transport client
- * @property serverVersionsEndpointUrl used to know which partner to communicate with
+ * @property partnerId used to know which partner to communicate with
  * @property partnerRepository used to get information about the partner (endpoint, token)
  */
 class TokensCpoClient(
     private val transportClientBuilder: TransportClientBuilder,
-    private val serverVersionsEndpointUrl: String,
+    private val partnerId: String,
     private val partnerRepository: PartnerRepository
 ) : TokensEmspInterface {
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.tokens,
-            partnerUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             partnerRepository = partnerRepository
         )
 
@@ -52,7 +52,7 @@ class TokensCpoClient(
                         requestId = generateRequestId(),
                         correlationId = generateCorrelationId()
                     )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             )
                 .parsePaginatedBody(offset)
         }
@@ -61,7 +61,7 @@ class TokensCpoClient(
         previousResponse: OcpiResponseBody<SearchResult<Token>>
     ): OcpiResponseBody<SearchResult<Token>>? = getNextPage(
         transportClientBuilder = transportClientBuilder,
-        serverVersionsEndpointUrl = serverVersionsEndpointUrl,
+        partnerId = partnerId,
         partnerRepository = partnerRepository,
         previousResponse = previousResponse
     )
@@ -83,7 +83,7 @@ class TokensCpoClient(
                         requestId = generateRequestId(),
                         correlationId = generateCorrelationId()
                     )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             ).parseBody()
         }
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
@@ -14,19 +14,19 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 /**
  * Sends calls to the CPO
  * @property transportClientBuilder used to build transport client
- * @property serverVersionsEndpointUrl used to know which partner to communicate with
+ * @property partnerId used to know which partner to communicate with
  * @property partnerRepository used to get information about the partner (endpoint, token)
  */
 class TokensEmspClient(
     private val transportClientBuilder: TransportClientBuilder,
-    private val serverVersionsEndpointUrl: String,
+    private val partnerId: String,
     private val partnerRepository: PartnerRepository
 ) : TokensCpoInterface {
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
             module = ModuleID.tokens,
-            partnerUrl = serverVersionsEndpointUrl,
+            partnerId = partnerId,
             partnerRepository = partnerRepository
         )
 
@@ -47,7 +47,7 @@ class TokensEmspClient(
                         requestId = generateRequestId(),
                         correlationId = generateCorrelationId()
                     )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             ).parseBody()
         }
 
@@ -72,7 +72,7 @@ class TokensEmspClient(
                         requestId = generateRequestId(),
                         correlationId = generateCorrelationId()
                     )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             ).parseBody()
         }
 
@@ -97,7 +97,7 @@ class TokensEmspClient(
                         requestId = generateRequestId(),
                         correlationId = generateCorrelationId()
                     )
-                    .authenticate(partnerRepository = partnerRepository, partnerUrl = serverVersionsEndpointUrl)
+                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId)
             ).parseBody()
         }
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionDetailsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionDetailsClient.kt
@@ -10,12 +10,12 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 /**
  * Used to get the version details of a partner
  * @property transportClientBuilder used to build transport client
- * @property serverVersionsEndpointUrl used to know which partner to communicate with
+ * @property partnerId used to know which partner to communicate with
  * @property partnerRepository used to get information about the partner (endpoint, token)
  */
 class VersionDetailsClient(
     private val transportClientBuilder: TransportClientBuilder,
-    private val serverVersionsEndpointUrl: String,
+    private val partnerId: String,
     private val partnerRepository: PartnerRepository
 ) : VersionDetailsInterface {
 
@@ -24,7 +24,7 @@ class VersionDetailsClient(
             transportClientBuilder
                 .build(
                     baseUrl = partnerRepository
-                        .getVersion(partnerUrl = serverVersionsEndpointUrl)
+                        .getVersion(partnerId = partnerId)
                         ?.url
                         ?: throw OcpiToolkitUnknownEndpointException("version details")
                 )
@@ -37,7 +37,7 @@ class VersionDetailsClient(
                     )
                     .authenticate(
                         partnerRepository = partnerRepository,
-                        partnerUrl = serverVersionsEndpointUrl,
+                        partnerId = partnerId,
                         allowTokenA = true
                     )
             )

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsClient.kt
@@ -15,6 +15,7 @@ import com.izivia.ocpi.toolkit.transport.domain.*
 class VersionsClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val serverVersionsEndpointUrl: String,
+    private val partnerId: String,
     private val partnerRepository: PartnerRepository
 ) : VersionsInterface {
 
@@ -31,7 +32,7 @@ class VersionsClient(
                     )
                     .authenticate(
                         partnerRepository = partnerRepository,
-                        partnerUrl = serverVersionsEndpointUrl,
+                        partnerId = partnerId,
                         allowTokenA = true
                     )
             )

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsClient.kt
@@ -9,12 +9,11 @@ import com.izivia.ocpi.toolkit.transport.domain.*
 /**
  * Used to get the versions of a partner
  * @property transportClientBuilder used to build transport client
- * @property serverVersionsEndpointUrl used to know which partner to communicate with
+ * @property partnerId used to know which partner to communicate with
  * @property partnerRepository used to get information about the partner (token)
  */
 class VersionsClient(
     private val transportClientBuilder: TransportClientBuilder,
-    private val serverVersionsEndpointUrl: String,
     private val partnerId: String,
     private val partnerRepository: PartnerRepository
 ) : VersionsInterface {
@@ -22,7 +21,11 @@ class VersionsClient(
     override suspend fun getVersions(): OcpiResponseBody<List<Version>> =
         with(
             transportClientBuilder
-                .build(baseUrl = serverVersionsEndpointUrl)
+                .build(
+                    baseUrl = partnerRepository
+                        .getPartnerUrl(partnerId = partnerId)
+                        ?: throw OcpiToolkitUnknownEndpointException("version with no url")
+                )
         ) {
             send(
                 HttpRequest(method = HttpMethod.GET)
@@ -43,7 +46,7 @@ class VersionsClient(
                     this.parseBody<OcpiResponseBody<List<Version>>>()
                 }
                 .onFailure {
-                    throw OcpiToolkitResponseParsingException(serverVersionsEndpointUrl, it)
+                    throw OcpiToolkitResponseParsingException(partnerId, it)
                 }
                 .getOrThrow()
         }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/DummyPartnerCacheRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/DummyPartnerCacheRepository.kt
@@ -4,6 +4,8 @@ class DummyPartnerCacheRepository : PartnerCacheRepository() {
     override suspend fun isCredentialsServerTokenValid(credentialsServerToken: String): Boolean =
         true
 
+    override suspend fun getPartnerUrl(partnerId: String): String = partnerId
+
     override suspend fun getCredentialsClientToken(partnerId: String): String =
         "*"
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/DummyPartnerCacheRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/DummyPartnerCacheRepository.kt
@@ -4,6 +4,6 @@ class DummyPartnerCacheRepository : PartnerCacheRepository() {
     override suspend fun isCredentialsServerTokenValid(credentialsServerToken: String): Boolean =
         true
 
-    override suspend fun getCredentialsClientToken(partnerUrl: String): String =
+    override suspend fun getCredentialsClientToken(partnerId: String): String =
         "*"
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PartnerCacheRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PartnerCacheRepository.kt
@@ -72,6 +72,9 @@ open class PartnerCacheRepository : PartnerRepository {
     override suspend fun isCredentialsServerTokenValid(credentialsServerToken: String): Boolean = partners
         .any { it.serverToken == credentialsServerToken }
 
+    override suspend fun getPartnerUrl(partnerId: String): String? = partners
+        .firstOrNull { it.url == partnerId }?.url
+
     override suspend fun getPartnerUrlByCredentialsServerToken(credentialsServerToken: String): String? = partners
         .firstOrNull { it.serverToken == credentialsServerToken }?.url
 

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PartnerCacheRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/PartnerCacheRepository.kt
@@ -28,43 +28,43 @@ open class PartnerCacheRepository : PartnerRepository {
         }
 
     override suspend fun saveCredentialsRoles(
-        partnerUrl: String,
+        partnerId: String,
         credentialsRoles: List<CredentialRole>
     ): List<CredentialRole> = partners
-        .getOrDefault(partnerUrl, Partner(partnerUrl))
+        .getOrDefault(partnerId, Partner(partnerId))
         .copy(credentialsRoles = credentialsRoles)
         .also { partners[it.url!!] = it }
         .credentialsRoles
 
-    override suspend fun saveVersion(partnerUrl: String, version: Version): Version = partners
-        .getOrDefault(partnerUrl, Partner(partnerUrl))
+    override suspend fun saveVersion(partnerId: String, version: Version): Version = partners
+        .getOrDefault(partnerId, Partner(partnerId))
         .copy(version = version)
         .also { partners[it.url!!] = it }
         .let { it.version!! }
 
-    override suspend fun saveEndpoints(partnerUrl: String, endpoints: List<Endpoint>): List<Endpoint> = partners
-        .getOrDefault(partnerUrl, Partner(partnerUrl))
+    override suspend fun saveEndpoints(partnerId: String, endpoints: List<Endpoint>): List<Endpoint> = partners
+        .getOrDefault(partnerId, Partner(partnerId))
         .copy(endpoints = endpoints)
         .also { partners[it.url!!] = it }
         .let { it.endpoints!! }
 
-    override suspend fun saveCredentialsClientToken(partnerUrl: String, credentialsClientToken: String): String =
+    override suspend fun saveCredentialsClientToken(partnerId: String, credentialsClientToken: String): String =
         partners
-            .getOrDefault(partnerUrl, Partner(partnerUrl))
+            .getOrDefault(partnerId, Partner(partnerId))
             .copy(clientToken = credentialsClientToken)
             .also { partners[it.url!!] = it }
             .let { it.clientToken!! }
 
-    override suspend fun saveCredentialsServerToken(partnerUrl: String, credentialsServerToken: String): String =
+    override suspend fun saveCredentialsServerToken(partnerId: String, credentialsServerToken: String): String =
         partners
-            .getOrDefault(partnerUrl, Partner(partnerUrl))
+            .getOrDefault(partnerId, Partner(partnerId))
             .copy(serverToken = credentialsServerToken)
             .also { partners[it.url!!] = it }
             .let { it.serverToken!! }
 
-    override suspend fun getCredentialsClientToken(partnerUrl: String): String? = partners[partnerUrl]?.clientToken
+    override suspend fun getCredentialsClientToken(partnerId: String): String? = partners[partnerId]?.clientToken
 
-    override suspend fun getCredentialsTokenA(partnerUrl: String): String? = partners[partnerUrl]?.tokenA
+    override suspend fun getCredentialsTokenA(partnerId: String): String? = partners[partnerId]?.tokenA
 
     override suspend fun isCredentialsTokenAValid(credentialsTokenA: String): Boolean = partners
         .any { it.tokenA == credentialsTokenA }
@@ -75,29 +75,35 @@ open class PartnerCacheRepository : PartnerRepository {
     override suspend fun getPartnerUrlByCredentialsServerToken(credentialsServerToken: String): String? = partners
         .firstOrNull { it.serverToken == credentialsServerToken }?.url
 
-    override suspend fun getEndpoints(partnerUrl: String): List<Endpoint> = partners
-        .firstOrNull { it.url == partnerUrl }?.endpoints ?: emptyList()
+    override suspend fun getPartnerIdByCredentialsServerToken(credentialsServerToken: String): String? = partners
+        .firstOrNull { it.serverToken == credentialsServerToken }?.url
 
-    override suspend fun getVersion(partnerUrl: String): Version? = partners
-        .firstOrNull { it.url == partnerUrl }?.version
+    override suspend fun getPartnerIdByCredentialsTokenA(credentialsTokenA: String): String? = partners
+        .firstOrNull { it.tokenA == credentialsTokenA }?.url
 
-    override suspend fun invalidateCredentialsTokenA(partnerUrl: String): Boolean =
+    override suspend fun getEndpoints(partnerId: String): List<Endpoint> = partners
+        .firstOrNull { it.url == partnerId }?.endpoints ?: emptyList()
+
+    override suspend fun getVersion(partnerId: String): Version? = partners
+        .firstOrNull { it.url == partnerId }?.version
+
+    override suspend fun invalidateCredentialsTokenA(partnerId: String): Boolean =
         partners
-            .getOrDefault(partnerUrl, Partner(partnerUrl))
+            .getOrDefault(partnerId, Partner(partnerId))
             .copy(tokenA = null)
             .also { partners[it.url!!] = it }
             .let { true }
 
-    override suspend fun invalidateCredentialsClientToken(partnerUrl: String): Boolean =
+    override suspend fun invalidateCredentialsClientToken(partnerId: String): Boolean =
         partners
-            .getOrDefault(partnerUrl, Partner(partnerUrl))
+            .getOrDefault(partnerId, Partner(partnerId))
             .copy(clientToken = null)
             .also { partners[it.url!!] = it }
             .let { true }
 
-    override suspend fun invalidateCredentialsServerToken(partnerUrl: String): Boolean =
+    override suspend fun invalidateCredentialsServerToken(partnerId: String): Boolean =
         partners
-            .getOrDefault(partnerUrl, Partner(partnerUrl))
+            .getOrDefault(partnerId, Partner(partnerId))
             .copy(serverToken = null)
             .also { partners[it.url!!] = it }
             .let { true }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsSender.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsSender.kt
@@ -67,7 +67,6 @@ fun main() {
                 )
             )
         },
-        serverVersionsEndpointUrl = receiverVersionsUrl,
         partnerId = receiverVersionsUrl,
         transportClientBuilder = Http4kTransportClientBuilder(),
         requiredEndpoints = RequiredEndpoints(receiver = listOf(ModuleID.credentials))

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsSender.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsSender.kt
@@ -68,6 +68,7 @@ fun main() {
             )
         },
         serverVersionsEndpointUrl = receiverVersionsUrl,
+        partnerId = receiverVersionsUrl,
         transportClientBuilder = Http4kTransportClientBuilder(),
         requiredEndpoints = RequiredEndpoints(receiver = listOf(ModuleID.credentials))
     )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsCpoClient.kt
@@ -11,7 +11,7 @@ fun main() {
     // We instantiate the clients that we want to use
     val locationsCpoClient = LocationsCpoClient(
         transportClientBuilder = Http4kTransportClientBuilder(),
-        serverVersionsEndpointUrl = emspServerVersionsUrl,
+        partnerId = emspServerVersionsUrl,
         partnerRepository = DUMMY_PLATFORM_REPOSITORY
     )
 

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsEmspClient.kt
@@ -11,7 +11,7 @@ fun main() {
     // We instantiate the clients that we want to use
     val locationsEmspClient = LocationsEmspClient(
         transportClientBuilder = Http4kTransportClientBuilder(),
-        serverVersionsEndpointUrl = cpoServerVersionsUrl,
+        partnerId = cpoServerVersionsUrl,
         partnerRepository = DUMMY_PLATFORM_REPOSITORY
     )
 

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/CredentialsIntegrationTests.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/CredentialsIntegrationTests.kt
@@ -145,6 +145,7 @@ class CredentialsIntegrationTests : BaseServerIntegrationTest() {
                 )
             },
             serverVersionsEndpointUrl = receiverServerSetupResult.versionsEndpoint,
+            partnerId = receiverServerSetupResult.versionsEndpoint,
             transportClientBuilder = Http4kTransportClientBuilder(),
             requiredEndpoints = requiredEndpoints
         )
@@ -223,6 +224,7 @@ class CredentialsIntegrationTests : BaseServerIntegrationTest() {
         val versionsClient = VersionsClient(
             transportClientBuilder = Http4kTransportClientBuilder(),
             serverVersionsEndpointUrl = receiverServer.versionsEndpoint,
+            partnerId = receiverServer.versionsEndpoint,
             partnerRepository = PartnerMongoRepository(collection = senderServer.partnerCollection)
         )
 
@@ -446,6 +448,7 @@ class CredentialsIntegrationTests : BaseServerIntegrationTest() {
         val versionsClient = VersionsClient(
             transportClientBuilder = Http4kTransportClientBuilder(),
             serverVersionsEndpointUrl = receiverServer.versionsEndpoint,
+            partnerId = receiverServer.versionsEndpoint,
             partnerRepository = PartnerMongoRepository(collection = senderServer.partnerCollection)
         )
 
@@ -496,11 +499,13 @@ class CredentialsIntegrationTests : BaseServerIntegrationTest() {
         val senderVersionsClient = VersionsClient(
             transportClientBuilder = Http4kTransportClientBuilder(),
             serverVersionsEndpointUrl = receiverServer.versionsEndpoint,
+            partnerId = receiverServer.versionsEndpoint,
             partnerRepository = PartnerMongoRepository(collection = senderServer.partnerCollection)
         )
         val receiverVersionsClient = VersionsClient(
             transportClientBuilder = Http4kTransportClientBuilder(),
             serverVersionsEndpointUrl = senderServer.versionsEndpoint,
+            partnerId = senderServer.versionsEndpoint,
             partnerRepository = PartnerMongoRepository(collection = receiverServer.partnerCollection)
         )
 
@@ -613,11 +618,13 @@ class CredentialsIntegrationTests : BaseServerIntegrationTest() {
         val senderVersionsClient = VersionsClient(
             transportClientBuilder = Http4kTransportClientBuilder(),
             serverVersionsEndpointUrl = receiverServer.versionsEndpoint,
+            partnerId = receiverServer.versionsEndpoint,
             partnerRepository = PartnerMongoRepository(collection = senderServer.partnerCollection)
         )
         val receiverVersionsClient = VersionsClient(
             transportClientBuilder = Http4kTransportClientBuilder(),
             serverVersionsEndpointUrl = senderServer.versionsEndpoint,
+            partnerId = senderServer.versionsEndpoint,
             partnerRepository = PartnerMongoRepository(collection = receiverServer.partnerCollection)
         )
 

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/CredentialsIntegrationTests.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/CredentialsIntegrationTests.kt
@@ -144,7 +144,6 @@ class CredentialsIntegrationTests : BaseServerIntegrationTest() {
                     )
                 )
             },
-            serverVersionsEndpointUrl = receiverServerSetupResult.versionsEndpoint,
             partnerId = receiverServerSetupResult.versionsEndpoint,
             transportClientBuilder = Http4kTransportClientBuilder(),
             requiredEndpoints = requiredEndpoints
@@ -223,7 +222,6 @@ class CredentialsIntegrationTests : BaseServerIntegrationTest() {
 
         val versionsClient = VersionsClient(
             transportClientBuilder = Http4kTransportClientBuilder(),
-            serverVersionsEndpointUrl = receiverServer.versionsEndpoint,
             partnerId = receiverServer.versionsEndpoint,
             partnerRepository = PartnerMongoRepository(collection = senderServer.partnerCollection)
         )
@@ -447,7 +445,6 @@ class CredentialsIntegrationTests : BaseServerIntegrationTest() {
 
         val versionsClient = VersionsClient(
             transportClientBuilder = Http4kTransportClientBuilder(),
-            serverVersionsEndpointUrl = receiverServer.versionsEndpoint,
             partnerId = receiverServer.versionsEndpoint,
             partnerRepository = PartnerMongoRepository(collection = senderServer.partnerCollection)
         )
@@ -498,13 +495,11 @@ class CredentialsIntegrationTests : BaseServerIntegrationTest() {
 
         val senderVersionsClient = VersionsClient(
             transportClientBuilder = Http4kTransportClientBuilder(),
-            serverVersionsEndpointUrl = receiverServer.versionsEndpoint,
             partnerId = receiverServer.versionsEndpoint,
             partnerRepository = PartnerMongoRepository(collection = senderServer.partnerCollection)
         )
         val receiverVersionsClient = VersionsClient(
             transportClientBuilder = Http4kTransportClientBuilder(),
-            serverVersionsEndpointUrl = senderServer.versionsEndpoint,
             partnerId = senderServer.versionsEndpoint,
             partnerRepository = PartnerMongoRepository(collection = receiverServer.partnerCollection)
         )
@@ -617,13 +612,11 @@ class CredentialsIntegrationTests : BaseServerIntegrationTest() {
 
         val senderVersionsClient = VersionsClient(
             transportClientBuilder = Http4kTransportClientBuilder(),
-            serverVersionsEndpointUrl = receiverServer.versionsEndpoint,
             partnerId = receiverServer.versionsEndpoint,
             partnerRepository = PartnerMongoRepository(collection = senderServer.partnerCollection)
         )
         val receiverVersionsClient = VersionsClient(
             transportClientBuilder = Http4kTransportClientBuilder(),
-            serverVersionsEndpointUrl = senderServer.versionsEndpoint,
             partnerId = senderServer.versionsEndpoint,
             partnerRepository = PartnerMongoRepository(collection = receiverServer.partnerCollection)
         )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/LocationsIntegrationTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/LocationsIntegrationTest.kt
@@ -76,7 +76,7 @@ class LocationsIntegrationTest : BaseServerIntegrationTest() {
 
         val locationsEmspClient = LocationsEmspClient(
             transportClientBuilder = Http4kTransportClientBuilder(),
-            serverVersionsEndpointUrl = cpoServerVersionsUrl,
+            partnerId = cpoServerVersionsUrl,
             partnerRepository = partnerRepo
         )
 

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PartnerMongoRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PartnerMongoRepository.kt
@@ -66,6 +66,9 @@ class PartnerMongoRepository(
     override suspend fun isCredentialsServerTokenValid(credentialsServerToken: String): Boolean = collection
         .findOne(Partner::serverToken eq credentialsServerToken) != null
 
+    override suspend fun getPartnerUrl(partnerId: String): String? = collection
+        .findOne(Partner::url eq partnerId)?.url
+
     override suspend fun getPartnerUrlByCredentialsServerToken(credentialsServerToken: String): String? = collection
         .findOne(Partner::serverToken eq credentialsServerToken)?.url
 

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PartnerMongoRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/mock/PartnerMongoRepository.kt
@@ -24,41 +24,41 @@ class PartnerMongoRepository(
             ?.url
 
     override suspend fun saveCredentialsRoles(
-        partnerUrl: String,
+        partnerId: String,
         credentialsRoles: List<CredentialRole>
     ): List<CredentialRole> =
         credentialsRoles.also {
             collection
-                .updateOne(Partner::url eq partnerUrl, set(Partner::credentialsRoles setTo it))
+                .updateOne(Partner::url eq partnerId, set(Partner::credentialsRoles setTo it))
         }
 
-    override suspend fun saveVersion(partnerUrl: String, version: Version): Version = version.also {
+    override suspend fun saveVersion(partnerId: String, version: Version): Version = version.also {
         collection
-            .updateOne(Partner::url eq partnerUrl, set(Partner::version setTo it))
+            .updateOne(Partner::url eq partnerId, set(Partner::version setTo it))
     }
 
-    override suspend fun saveEndpoints(partnerUrl: String, endpoints: List<Endpoint>): List<Endpoint> = endpoints.also {
+    override suspend fun saveEndpoints(partnerId: String, endpoints: List<Endpoint>): List<Endpoint> = endpoints.also {
         collection
-            .updateOne(Partner::url eq partnerUrl, set(Partner::endpoints setTo it))
+            .updateOne(Partner::url eq partnerId, set(Partner::endpoints setTo it))
     }
 
-    override suspend fun saveCredentialsClientToken(partnerUrl: String, credentialsClientToken: String): String =
+    override suspend fun saveCredentialsClientToken(partnerId: String, credentialsClientToken: String): String =
         credentialsClientToken.also {
             collection
-                .updateOne(Partner::url eq partnerUrl, set(Partner::clientToken setTo it))
+                .updateOne(Partner::url eq partnerId, set(Partner::clientToken setTo it))
         }
 
-    override suspend fun saveCredentialsServerToken(partnerUrl: String, credentialsServerToken: String): String =
+    override suspend fun saveCredentialsServerToken(partnerId: String, credentialsServerToken: String): String =
         credentialsServerToken.also {
             collection
-                .updateOne(Partner::url eq partnerUrl, set(Partner::serverToken setTo it))
+                .updateOne(Partner::url eq partnerId, set(Partner::serverToken setTo it))
         }
 
-    override suspend fun getCredentialsTokenA(partnerUrl: String): String? = collection
-        .findOne(Partner::url eq partnerUrl)?.tokenA
+    override suspend fun getCredentialsTokenA(partnerId: String): String? = collection
+        .findOne(Partner::url eq partnerId)?.tokenA
 
-    override suspend fun getCredentialsClientToken(partnerUrl: String): String? = collection
-        .findOne(Partner::url eq partnerUrl)?.clientToken
+    override suspend fun getCredentialsClientToken(partnerId: String): String? = collection
+        .findOne(Partner::url eq partnerId)?.clientToken
 
     override suspend fun isCredentialsTokenAValid(credentialsTokenA: String): Boolean = collection
         .findOne(Partner::tokenA eq credentialsTokenA) != null
@@ -69,31 +69,38 @@ class PartnerMongoRepository(
     override suspend fun getPartnerUrlByCredentialsServerToken(credentialsServerToken: String): String? = collection
         .findOne(Partner::serverToken eq credentialsServerToken)?.url
 
-    override suspend fun getEndpoints(partnerUrl: String): List<Endpoint> = collection
-        .findOne(Partner::url eq partnerUrl)?.endpoints ?: emptyList()
+    override suspend fun getPartnerIdByCredentialsServerToken(credentialsServerToken: String): String? = collection
+        .findOne(Partner::serverToken eq credentialsServerToken)?.url
 
-    override suspend fun getVersion(partnerUrl: String): Version? = collection
-        .findOne(Partner::url eq partnerUrl)?.version
+    override suspend fun getPartnerIdByCredentialsTokenA(credentialsTokenA: String): String? = collection.findOne(
+        Partner::tokenA eq credentialsTokenA
+    )?.url
 
-    override suspend fun invalidateCredentialsTokenA(partnerUrl: String): Boolean =
+    override suspend fun getEndpoints(partnerId: String): List<Endpoint> = collection
+        .findOne(Partner::url eq partnerId)?.endpoints ?: emptyList()
+
+    override suspend fun getVersion(partnerId: String): Version? = collection
+        .findOne(Partner::url eq partnerId)?.version
+
+    override suspend fun invalidateCredentialsTokenA(partnerId: String): Boolean =
         collection
-            .updateOne(Partner::url eq partnerUrl, set(Partner::tokenA setTo null))
+            .updateOne(Partner::url eq partnerId, set(Partner::tokenA setTo null))
             .matchedCount == 1L
 
-    override suspend fun invalidateCredentialsClientToken(partnerUrl: String): Boolean =
+    override suspend fun invalidateCredentialsClientToken(partnerId: String): Boolean =
         collection
             .updateOne(
-                Partner::url eq partnerUrl,
+                Partner::url eq partnerId,
                 combine(
                     set(Partner::clientToken setTo null)
                 )
             )
             .matchedCount == 1L
 
-    override suspend fun invalidateCredentialsServerToken(partnerUrl: String): Boolean =
+    override suspend fun invalidateCredentialsServerToken(partnerId: String): Boolean =
         collection
             .updateOne(
-                Partner::url eq partnerUrl,
+                Partner::url eq partnerId,
                 combine(
                     set(Partner::serverToken setTo null)
                 )


### PR DESCRIPTION
Rename parameter `partnerUrl` in search method to allow the usage of another field as a unique identifier for partners
Fix issue: https://github.com/IZIVIA/ocpi-toolkit/issues/132

:warning: This changes may be breaking change for user  