### PR TITLE
fix(commands) #132: missing changes in command module

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpAuthInterface.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpAuthInterface.kt
@@ -6,9 +6,9 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
  * Example implementation
  *
  *     httpAuth = { req ->
- *       partnerRepository.getPartnerUrlByCredentialsServerToken(req.parseAuthorizationHeader())!!
+ *       partnerRepository.getPartnerIdByCredentialsServerToken(req.parseAuthorizationHeader())!!
  *     }
  */
 fun interface HttpAuthInterface {
-    suspend fun partnerUrlFromRequest(req: HttpRequest): String
+    suspend fun partnerIdFromRequest(req: HttpRequest): String
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoInterface.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoInterface.kt
@@ -5,27 +5,27 @@ import com.izivia.ocpi.toolkit.modules.commands.domain.*
 
 interface CommandCpoInterface {
     suspend fun postStartSession(
-        partnerUrl: String,
+        partnerId: String,
         startSession: StartSession,
     ): OcpiResponseBody<CommandResponse>
 
     suspend fun postStopSession(
-        partnerUrl: String,
+        partnerId: String,
         stopSession: StopSession,
     ): OcpiResponseBody<CommandResponse>
 
     suspend fun postReserveNow(
-        partnerUrl: String,
+        partnerId: String,
         reserveNow: ReserveNow,
     ): OcpiResponseBody<CommandResponse>
 
     suspend fun postCancelReservation(
-        partnerUrl: String,
+        partnerId: String,
         cancelReservation: CancelReservation,
     ): OcpiResponseBody<CommandResponse>
 
     suspend fun postUnlockConnector(
-        partnerUrl: String,
+        partnerId: String,
         unlockConnector: UnlockConnector,
     ): OcpiResponseBody<CommandResponse>
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoServer.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoServer.kt
@@ -31,11 +31,11 @@ class CommandCpoServer(
             method = HttpMethod.POST,
             path = basePathSegments + FixedPathSegment("START_SESSION"),
         ) { req ->
-            val senderPlatformUrl = httpAuth.partnerUrlFromRequest(req)
+            val senderPlatformId = httpAuth.partnerIdFromRequest(req)
             val startSession = mapper.readValue(req.body, StartSession::class.java)
 
             req.httpResponse {
-                service.postStartSession(senderPlatformUrl, startSession)
+                service.postStartSession(senderPlatformId, startSession)
             }
         }
 
@@ -43,7 +43,7 @@ class CommandCpoServer(
             method = HttpMethod.POST,
             path = basePathSegments + FixedPathSegment("STOP_SESSION"),
         ) { req ->
-            val senderPlatformUrl = httpAuth.partnerUrlFromRequest(req)
+            val senderPlatformUrl = httpAuth.partnerIdFromRequest(req)
             val stopSession = mapper.readValue(req.body, StopSession::class.java)
 
             req.httpResponse {
@@ -55,7 +55,7 @@ class CommandCpoServer(
             method = HttpMethod.POST,
             path = basePathSegments + FixedPathSegment("RESERVE_NOW"),
         ) { req ->
-            val senderPlatformUrl = httpAuth.partnerUrlFromRequest(req)
+            val senderPlatformUrl = httpAuth.partnerIdFromRequest(req)
             val reserveNow = mapper.readValue(req.body, ReserveNow::class.java)
 
             req.httpResponse {
@@ -67,7 +67,7 @@ class CommandCpoServer(
             method = HttpMethod.POST,
             path = basePathSegments + FixedPathSegment("CANCEL_RESERVATION"),
         ) { req ->
-            val senderPlatformUrl = httpAuth.partnerUrlFromRequest(req)
+            val senderPlatformUrl = httpAuth.partnerIdFromRequest(req)
             val cancelReservation = mapper.readValue(req.body, CancelReservation::class.java)
 
             req.httpResponse {
@@ -79,7 +79,7 @@ class CommandCpoServer(
             method = HttpMethod.POST,
             path = basePathSegments + FixedPathSegment("UNLOCK_CONNECTOR"),
         ) { req ->
-            val senderPlatformUrl = httpAuth.partnerUrlFromRequest(req)
+            val senderPlatformUrl = httpAuth.partnerIdFromRequest(req)
             val unlockConnector = mapper.readValue(req.body, UnlockConnector::class.java)
 
             req.httpResponse {


### PR DESCRIPTION
we are passing this value to the service, which in turn will pass it to the client which requires a partnerId, not a url