### PR TITLE
fix(credentials): move the tokenA invalidation after getCredential

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
@@ -61,16 +61,16 @@ open class CredentialsServerService(
             debugHeaders = debugHeaders,
         )
 
-        // Remove token A because it is useless from now on
-        partnerRepository.invalidateCredentialsTokenA(partnerId = partnerId)
-
         // Return Credentials objet to sender with the token C inside (which is for us the server token)
         getCredentials(
             serverToken = partnerRepository.saveCredentialsServerToken(
                 partnerId = partnerId,
                 credentialsServerToken = generateUUIDv4Token(),
             ),
-        )
+        ).also {
+            // Remove token A because it is useless from now on
+            partnerRepository.invalidateCredentialsTokenA(partnerId = partnerId)
+        }
     }
 
     override suspend fun put(


### PR DESCRIPTION
Move the tokenA invalidation after getCredential in CredentialsServerService, because it is the one that is in the context and used during getCredential

Closes https://github.com/IZIVIA/ocpi-toolkit/issues/138