### PR TITLE
fix(mapper): Datetime (instant) parsing was not working if Z was present at the end & added Z at the end for better compat

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiInstantDeserializer.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiInstantDeserializer.kt
@@ -4,14 +4,17 @@ import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
 
 class OcpiInstantDeserializer : StdDeserializer<Instant>(Instant::class.java) {
     override fun deserialize(parser: JsonParser, context: DeserializationContext): Instant {
-        val value = parser.text.trim()
-        val localDateTime = LocalDateTime.parse(value, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-        return localDateTime.atOffset(ZoneOffset.UTC).toInstant()
+        return Instant.parse(
+            parser.valueAsString.run {
+                if (!endsWith("Z")) {
+                    "${this}Z"
+                } else {
+                    this
+                }
+            },
+        )
     }
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiInstantSerializer.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiInstantSerializer.kt
@@ -11,9 +11,11 @@ import java.time.temporal.ChronoUnit
 class OcpiInstantSerializer : StdSerializer<Instant>(Instant::class.java) {
     override fun serialize(value: Instant?, gen: JsonGenerator, provider: SerializerProvider) {
         if (value != null) {
-            val formatted = value.truncatedTo(ChronoUnit.MILLIS).atOffset(ZoneOffset.UTC)
-                .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-            gen.writeString(formatted)
+            gen.writeString(
+                value.truncatedTo(ChronoUnit.MILLIS)
+                    .atOffset(ZoneOffset.UTC)
+                    .format(DateTimeFormatter.ISO_INSTANT),
+            )
         } else {
             gen.writeNull()
         }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/mappers/MappersTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/mappers/MappersTest.kt
@@ -1,19 +1,27 @@
 package com.izivia.ocpi.toolkit.mappers
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.izivia.ocpi.toolkit.common.mapper
 import com.izivia.ocpi.toolkit.modules.isJsonEqualTo
-import com.izivia.ocpi.toolkit.modules.locations.domain.*
+import com.izivia.ocpi.toolkit.modules.locations.domain.GeoLocation
+import com.izivia.ocpi.toolkit.modules.locations.domain.Location
+import com.izivia.ocpi.toolkit.modules.locations.domain.ParkingType
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
+import strikt.assertions.isEqualTo
 import java.time.Instant
 
 class MappersTest {
+    data class InstantWrapper(
+        val instant: Instant,
+    )
+
     @Test
     fun `should truncate instants when exceeds 25 characters`() {
         val location = buildLocation(Instant.parse("2018-01-01T01:08:01.123456789Z")) // contains 30 characters
 
         expectThat(mapper.writeValueAsString(location))
-            .isJsonEqualTo(jsonLocation("2018-01-01T01:08:01.123"))
+            .isJsonEqualTo(jsonLocation("2018-01-01T01:08:01.123Z"))
     }
 
     @Test
@@ -23,7 +31,25 @@ class MappersTest {
         expectThat(
             mapper.writeValueAsString(location),
         ).isJsonEqualTo(
-            jsonLocation("2018-01-01T01:08:01.123"),
+            jsonLocation("2018-01-01T01:08:01.123Z"),
+        )
+    }
+
+    @Test
+    fun `should properly parse with and without Z`() {
+        val instantWithZ = "2025-03-05T10:37:42.42Z"
+        val instantWithoutZ = "2025-03-05T10:37:42.42"
+
+        expectThat(
+            mapper.readValue<InstantWrapper>("""{"instant": "$instantWithZ"}"""),
+        ).isEqualTo(
+            InstantWrapper(Instant.parse(instantWithZ)),
+        )
+
+        expectThat(
+            mapper.readValue<InstantWrapper>("""{"instant": "$instantWithoutZ"}"""),
+        ).isEqualTo(
+            InstantWrapper(Instant.parse(instantWithZ)),
         )
     }
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/cpo/LocationsCpoHttpGetConnectorTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/cpo/LocationsCpoHttpGetConnectorTest.kt
@@ -79,11 +79,11 @@ class LocationsCpoHttpGetConnectorTest {
                             "max_voltage": 220,
                             "max_amperage": 16,
                             "tariff_ids": ["11"],
-                            "last_updated": "2015-03-16T10:10:02"
+                            "last_updated": "2015-03-16T10:10:02Z"
                       },
                       "status_code": 1000,
                       "status_message": "Success",
-                      "timestamp": "2015-06-30T21:59:59"
+                      "timestamp": "2015-06-30T21:59:59Z"
                     }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/cpo/LocationsCpoHttpGetEvseTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/cpo/LocationsCpoHttpGetEvseTest.kt
@@ -97,7 +97,7 @@ class LocationsCpoHttpGetEvseTest {
                                 "max_voltage": 220,
                                 "max_amperage": 16,
                                 "tariff_ids": ["11"],
-                                "last_updated": "2015-03-16T10:10:02"
+                                "last_updated": "2015-03-16T10:10:02Z"
                               },
                               {
                                 "id": "2",
@@ -107,16 +107,16 @@ class LocationsCpoHttpGetEvseTest {
                                 "max_voltage": 220,
                                 "max_amperage": 16,
                                 "tariff_ids": ["13"],
-                                "last_updated": "2015-03-18T08:12:01"
+                                "last_updated": "2015-03-18T08:12:01Z"
                               }
                         ],
                         "physical_reference": "1",
                         "floor_level": "-1",
-                        "last_updated": "2015-06-28T08:12:01"
+                        "last_updated": "2015-06-28T08:12:01Z"
                   },
                   "status_code": 1000,
                   "status_message": "Success",
-                  "timestamp": "2015-06-30T21:59:59"
+                  "timestamp": "2015-06-30T21:59:59Z"
                 }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/cpo/LocationsCpoHttpGetLocationTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/cpo/LocationsCpoHttpGetLocationTest.kt
@@ -152,7 +152,7 @@ class LocationsCpoHttpGetLocationTest {
                                 "max_voltage": 220,
                                 "max_amperage": 16,
                                 "tariff_ids": ["11"],
-                                "last_updated": "2015-03-16T10:10:02"
+                                "last_updated": "2015-03-16T10:10:02Z"
                                 },
                                 {
                                 "id": "2",
@@ -162,12 +162,12 @@ class LocationsCpoHttpGetLocationTest {
                                 "max_voltage": 220,
                                 "max_amperage": 16,
                                 "tariff_ids": ["13"],
-                                "last_updated": "2015-03-18T08:12:01"
+                                "last_updated": "2015-03-18T08:12:01Z"
                                 }
                             ],
                             "physical_reference": "1",
                             "floor_level": "-1",
-                            "last_updated": "2015-06-28T08:12:01"
+                            "last_updated": "2015-06-28T08:12:01Z"
                             },
                             {
                             "uid": "3257",
@@ -185,23 +185,23 @@ class LocationsCpoHttpGetLocationTest {
                                 "max_voltage": 220,
                                 "max_amperage": 16,
                                 "tariff_ids": ["12"],
-                                "last_updated": "2015-06-29T20:39:09"
+                                "last_updated": "2015-06-29T20:39:09Z"
                                 }
                             ],
                             "physical_reference": "2",
                             "floor_level": "-2",
-                            "last_updated": "2015-06-29T20:39:09"
+                            "last_updated": "2015-06-29T20:39:09Z"
                             }
                         ],
                         "operator": {
                             "name": "BeCharged"
                         },
                         "time_zone": "Europe/Brussels",
-                        "last_updated": "2015-06-29T20:39:09"
+                        "last_updated": "2015-06-29T20:39:09Z"
                   },
                   "status_code": 1000,
                   "status_message": "Success",
-                  "timestamp": "2015-06-30T21:59:59"
+                  "timestamp": "2015-06-30T21:59:59Z"
                 }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/cpo/LocationsCpoHttpGetLocationsTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/cpo/LocationsCpoHttpGetLocationsTest.kt
@@ -120,22 +120,22 @@ class LocationsCpoHttpGetLocationsTest {
               "power_type": "AC_3_PHASE",
               "max_voltage": 220,
               "max_amperage": 16,
-              "last_updated": "2019-07-01T12:12:11"
+              "last_updated": "2019-07-01T12:12:11Z"
             }
           ],
           "parking_restrictions": [
             "CUSTOMERS"
           ],
-          "last_updated": "2019-07-01T12:12:11"
+          "last_updated": "2019-07-01T12:12:11Z"
         }
       ],
       "time_zone": "Europe/Amsterdam",
-      "last_updated": "2019-07-01T12:12:11"
+      "last_updated": "2019-07-01T12:12:11Z"
     }
   ],
   "status_code": 1000,
   "status_message": "Success",
-  "timestamp": "2015-06-30T21:59:59"
+  "timestamp": "2015-06-30T21:59:59Z"
 }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpGetConnectorTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpGetConnectorTest.kt
@@ -85,11 +85,11 @@ class LocationsEmspHttpGetConnectorTest {
                             "max_voltage": 220,
                             "max_amperage": 16,
                             "tariff_ids": ["11"],
-                            "last_updated": "2015-03-16T10:10:02"
+                            "last_updated": "2015-03-16T10:10:02Z"
                       },
                       "status_code": 1000,
                       "status_message": "Success",
-                      "timestamp": "2015-06-30T21:59:59"
+                      "timestamp": "2015-06-30T21:59:59Z"
                     }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpGetEvseTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpGetEvseTest.kt
@@ -108,7 +108,7 @@ class LocationsEmspHttpGetEvseTest {
                                 "max_voltage": 220,
                                 "max_amperage": 16,
                                 "tariff_ids": ["11"],
-                                "last_updated": "2015-03-16T10:10:02"
+                                "last_updated": "2015-03-16T10:10:02Z"
                               },
                               {
                                 "id": "2",
@@ -118,16 +118,16 @@ class LocationsEmspHttpGetEvseTest {
                                 "max_voltage": 220,
                                 "max_amperage": 16,
                                 "tariff_ids": ["13"],
-                                "last_updated": "2015-03-18T08:12:01"
+                                "last_updated": "2015-03-18T08:12:01Z"
                               }
                         ],
                         "physical_reference": "1",
                         "floor_level": "-1",
-                        "last_updated": "2015-06-28T08:12:01"
+                        "last_updated": "2015-06-28T08:12:01Z"
                   },
                   "status_code": 1000,
                   "status_message": "Success",
-                  "timestamp": "2015-06-30T21:59:59"
+                  "timestamp": "2015-06-30T21:59:59Z"
                 }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpGetLocationTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpGetLocationTest.kt
@@ -162,7 +162,7 @@ class LocationsEmspHttpGetLocationTest {
                                 "max_voltage": 220,
                                 "max_amperage": 16,
                                 "tariff_ids": ["11"],
-                                "last_updated": "2015-03-16T10:10:02"
+                                "last_updated": "2015-03-16T10:10:02Z"
                                 },
                                 {
                                 "id": "2",
@@ -172,12 +172,12 @@ class LocationsEmspHttpGetLocationTest {
                                 "max_voltage": 220,
                                 "max_amperage": 16,
                                 "tariff_ids": ["13"],
-                                "last_updated": "2015-03-18T08:12:01"
+                                "last_updated": "2015-03-18T08:12:01Z"
                                 }
                             ],
                             "physical_reference": "1",
                             "floor_level": "-1",
-                            "last_updated": "2015-06-28T08:12:01"
+                            "last_updated": "2015-06-28T08:12:01Z"
                             },
                             {
                             "uid": "3257",
@@ -195,23 +195,23 @@ class LocationsEmspHttpGetLocationTest {
                                 "max_voltage": 220,
                                 "max_amperage": 16,
                                 "tariff_ids": ["12"],
-                                "last_updated": "2015-06-29T20:39:09"
+                                "last_updated": "2015-06-29T20:39:09Z"
                                 }
                             ],
                             "physical_reference": "2",
                             "floor_level": "-2",
-                            "last_updated": "2015-06-29T20:39:09"
+                            "last_updated": "2015-06-29T20:39:09Z"
                             }
                         ],
                         "operator": {
                             "name": "BeCharged"
                         },
                         "time_zone": "Europe/Brussels",
-                        "last_updated": "2015-06-29T20:39:09"
+                        "last_updated": "2015-06-29T20:39:09Z"
                   },
                   "status_code": 1000,
                   "status_message": "Success",
-                  "timestamp": "2015-06-30T21:59:59"
+                  "timestamp": "2015-06-30T21:59:59Z"
                 }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpPatchConnectorTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpPatchConnectorTest.kt
@@ -91,7 +91,7 @@ class LocationsEmspHttpPatchConnectorTest {
                     {
                       "status_code": 1000,
                       "status_message": "Success",
-                      "timestamp": "2015-06-30T21:59:59"
+                      "timestamp": "2015-06-30T21:59:59Z"
                     }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpPatchEvseTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpPatchEvseTest.kt
@@ -112,7 +112,7 @@ class LocationsEmspHttpPatchEvseTest {
                 {
                   "status_code": 1000,
                   "status_message": "Success",
-                  "timestamp": "2015-06-30T21:59:59"
+                  "timestamp": "2015-06-30T21:59:59Z"
                 }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpPatchLocationTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpPatchLocationTest.kt
@@ -163,7 +163,7 @@ class LocationsEmspHttpPatchLocationTest {
                 {
                   "status_code": 1000,
                   "status_message": "Success",
-                  "timestamp": "2015-06-30T21:59:59"
+                  "timestamp": "2015-06-30T21:59:59Z"
                 }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpPutConnectorTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpPutConnectorTest.kt
@@ -83,7 +83,7 @@ class LocationsEmspHttpPutConnectorTest {
                     {
                       "status_code": 1000,
                       "status_message": "Success",
-                      "timestamp": "2015-06-30T21:59:59"
+                      "timestamp": "2015-06-30T21:59:59Z"
                     }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpPutEvseTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpPutEvseTest.kt
@@ -98,7 +98,7 @@ class LocationsEmspHttpPutEvseTest {
                 {
                   "status_code": 1000,
                   "status_message": "Success",
-                  "timestamp": "2015-06-30T21:59:59"
+                  "timestamp": "2015-06-30T21:59:59Z"
                 }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpPutLocationTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpPutLocationTest.kt
@@ -137,7 +137,7 @@ class LocationsEmspHttpPutLocationTest {
                 {
                   "status_code": 1000,
                   "status_message": "Success",
-                  "timestamp": "2015-06-30T21:59:59"
+                  "timestamp": "2015-06-30T21:59:59Z"
                 }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/tokens/http/cpo/TokensCpoHttpGetTokenTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/tokens/http/cpo/TokensCpoHttpGetTokenTest.kt
@@ -101,11 +101,11 @@ class TokensCpoHttpGetTokenTest {
                         "supplier_name": "Greenpeace Energy eG",
                         "contract_id": "0123456789"
                     },
-                    "last_updated": "2018-12-10T17:25:10"
+                    "last_updated": "2018-12-10T17:25:10Z"
                     },
                     "status_code": 1000,
                     "status_message": "Success",
-                    "timestamp": "2015-06-30T21:59:59"
+                    "timestamp": "2015-06-30T21:59:59Z"
                 }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/tokens/http/cpo/TokensCpoHttpPatchTokenTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/tokens/http/cpo/TokensCpoHttpPatchTokenTest.kt
@@ -85,7 +85,7 @@ class TokensCpoHttpPatchTokenTest {
                 {
                     "status_code": 1000,
                     "status_message": "Success",
-                    "timestamp": "2015-06-30T21:59:59"
+                    "timestamp": "2015-06-30T21:59:59Z"
                 }
                 """.trimIndent(),
             )
@@ -179,7 +179,7 @@ class TokensCpoHttpPatchTokenTest {
                 {
                     "status_code": 1000,
                     "status_message": "Success",
-                    "timestamp": "2015-06-30T21:59:59"
+                    "timestamp": "2015-06-30T21:59:59Z"
                 }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/tokens/http/cpo/TokensCpoHttpPutTokenTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/tokens/http/cpo/TokensCpoHttpPutTokenTest.kt
@@ -92,7 +92,7 @@ class TokensCpoHttpPutTokenTest {
                 {
                     "status_code": 1000,
                     "status_message": "Success",
-                    "timestamp": "2015-06-30T21:59:59"
+                    "timestamp": "2015-06-30T21:59:59Z"
                 }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/tokens/http/emsp/TokensEmspHttpGetTokensTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/tokens/http/emsp/TokensEmspHttpGetTokensTest.kt
@@ -97,11 +97,11 @@ class TokensEmspHttpGetTokensTest {
                         "supplier_name": "Greenpeace Energy eG",
                         "contract_id": "0123456789"
                     },
-                    "last_updated": "2018-12-10T17:25:10"
+                    "last_updated": "2018-12-10T17:25:10Z"
                     } ],
                     "status_code": 1000,
                     "status_message": "Success",
-                    "timestamp": "2015-06-30T21:59:59"
+                    "timestamp": "2015-06-30T21:59:59Z"
                 }
                 """.trimIndent(),
             )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/tokens/http/emsp/TokensEmspHttpPostTokenTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/tokens/http/emsp/TokensEmspHttpPostTokenTest.kt
@@ -98,12 +98,12 @@ class TokensEmspHttpPostTokenTest {
                             "supplier_name": "Greenpeace Energy eG",
                             "contract_id": "0123456789"
                         },
-                        "last_updated": "2018-12-10T17:25:10"
+                        "last_updated": "2018-12-10T17:25:10Z"
                     }
                     },
                     "status_code": 1000,
                     "status_message": "Success",
-                    "timestamp": "2015-06-30T21:59:59"
+                    "timestamp": "2015-06-30T21:59:59Z"
                 }
                 """.trimIndent(),
             )
@@ -192,12 +192,12 @@ class TokensEmspHttpPostTokenTest {
                             "supplier_name": "Greenpeace Energy eG",
                             "contract_id": "0123456789"
                         },
-                        "last_updated": "2018-12-10T17:25:10"
+                        "last_updated": "2018-12-10T17:25:10Z"
                     }
                     },
                     "status_code": 1000,
                     "status_message": "Success",
-                    "timestamp": "2015-06-30T21:59:59"
+                    "timestamp": "2015-06-30T21:59:59Z"
                 }
                 """.trimIndent(),
             )


### PR DESCRIPTION
fixes https://github.com/IZIVIA/ocpi-toolkit/issues/151

and makes sure ocpi-toolkit behavior is the same as 0.0.47