### PR TITLE
feat(codegen) #155: default all Partial fiels to null

### DIFF
--- a/annotation-processor/src/main/kotlin/com/izivia/ocpi/toolkit/processor/PartialProcessor.kt
+++ b/annotation-processor/src/main/kotlin/com/izivia/ocpi/toolkit/processor/PartialProcessor.kt
@@ -2,7 +2,10 @@ package com.izivia.ocpi.toolkit.processor
 
 import com.google.devtools.ksp.getConstructors
 import com.google.devtools.ksp.processing.*
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.validate
 import com.izivia.ocpi.toolkit.annotations.Partial
 import com.squareup.kotlinpoet.*
@@ -85,6 +88,7 @@ class PartialProcessor(
                         param.parameterName,
                         param.type.copy(nullable = true),
                     )
+                    .defaultValue("null")
                     .build()
             }
 


### PR DESCRIPTION
all partial fields are, by definition, nullable
setting all properties to null by default makes instance creation easier