### PR TITLE
fix(mapping) #151: timestamps with offset failed to deserialize

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -17,7 +17,7 @@ object Versions {
     const val logback = "1.4.14"
     const val junit = "5.10.1"
     const val http4k = "4.48.0.0"
-    const val strikt = "0.34.1"
+    const val strikt = "0.35.1"
     const val mockk = "1.13.8"
     const val testcontainers = "1.19.3"
     const val kmongo = "4.11.0"

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiInstantDeserializer.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiInstantDeserializer.kt
@@ -4,17 +4,17 @@ import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeParseException
 
 class OcpiInstantDeserializer : StdDeserializer<Instant>(Instant::class.java) {
     override fun deserialize(parser: JsonParser, context: DeserializationContext): Instant {
-        return Instant.parse(
-            parser.valueAsString.run {
-                if (!endsWith("Z")) {
-                    "${this}Z"
-                } else {
-                    this
-                }
-            },
-        )
+        return try {
+            Instant.parse(parser.valueAsString)
+        } catch (e: DateTimeParseException) {
+            // might be missing the timezone information, we'll just try again using LocalDateTime assuming UTC
+            LocalDateTime.parse(parser.valueAsString).toInstant(ZoneOffset.UTC)
+        }
     }
 }


### PR DESCRIPTION
adding the Z if timezone info missing would add it when offset was given instead, eg `2025-03-05T10:37:42.13+00:00` would get parsed as `2025-03-05T10:37:42.13+00:00Z`

instead of manipulating the incoming string we simply try various patterns