### PR TITLE
fix(commands): fix deserialization and client interface

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspClient.kt
@@ -31,6 +31,7 @@ class CommandEmspClient(
         evseId: CiString?,
         connectorId: CiString?,
         authorizationReference: CiString,
+        callbackReference: String = authorizationReference,
     ): CommandResponse =
         with(buildTransport()) {
             send(
@@ -39,7 +40,7 @@ class CommandEmspClient(
                     path = "/START_SESSION",
                     body = mapper.writeValueAsString(
                         StartSession(
-                            responseUrl = "$callbackBaseUrl/START_SESSION/callback/$authorizationReference",
+                            responseUrl = "$callbackBaseUrl/START_SESSION/callback/$callbackReference",
                             token = token,
                             locationId = locationId,
                             evseUid = evseId,
@@ -57,7 +58,10 @@ class CommandEmspClient(
                 .parseResult()
         }
 
-    suspend fun postStopSession(sessionId: String): CommandResponse =
+    suspend fun postStopSession(
+        sessionId: CiString,
+        callbackReference: String = sessionId,
+    ): CommandResponse =
         with(buildTransport()) {
             send(
                 HttpRequest(
@@ -65,7 +69,7 @@ class CommandEmspClient(
                     path = "/STOP_SESSION",
                     body = mapper.writeValueAsString(
                         StopSession(
-                            responseUrl = "$callbackBaseUrl/STOP_SESSION/callback/$sessionId",
+                            responseUrl = "$callbackBaseUrl/STOP_SESSION/callback/$callbackReference",
                             sessionId = sessionId,
                         ),
                     ),
@@ -86,6 +90,7 @@ class CommandEmspClient(
         locationId: CiString,
         evseUid: CiString?,
         authorizationReference: CiString?,
+        callbackReference: String = reservationId,
     ): CommandResponse =
         with(buildTransport()) {
             send(
@@ -94,7 +99,7 @@ class CommandEmspClient(
                     path = "/RESERVE_NOW",
                     body = mapper.writeValueAsString(
                         ReserveNow(
-                            responseUrl = "$callbackBaseUrl/RESERVE_NOW/callback/$reservationId",
+                            responseUrl = "$callbackBaseUrl/RESERVE_NOW/callback/$callbackReference",
                             token = token,
                             expiryDate = expiryDate,
                             reservationId = reservationId,
@@ -113,7 +118,10 @@ class CommandEmspClient(
                 .parseResult()
         }
 
-    suspend fun postCancelReservation(reservationId: CiString): CommandResponse =
+    suspend fun postCancelReservation(
+        reservationId: CiString,
+        callbackReference: String = reservationId,
+    ): CommandResponse =
         with(buildTransport()) {
             send(
                 HttpRequest(
@@ -121,7 +129,7 @@ class CommandEmspClient(
                     path = "/CANCEL_RESERVATION",
                     body = mapper.writeValueAsString(
                         CancelReservation(
-                            responseUrl = "$callbackBaseUrl/CANCEL_RESERVATION/callback/$reservationId",
+                            responseUrl = "$callbackBaseUrl/CANCEL_RESERVATION/callback/$callbackReference",
                             reservationId = reservationId,
                         ),
                     ),
@@ -139,6 +147,7 @@ class CommandEmspClient(
         locationId: CiString,
         evseUid: CiString,
         connectorId: CiString,
+        callbackReference: String,
     ): CommandResponse =
         with(buildTransport()) {
             send(
@@ -147,8 +156,7 @@ class CommandEmspClient(
                     path = "/UNLOCK_CONNECTOR",
                     body = mapper.writeValueAsString(
                         UnlockConnector(
-                            responseUrl =
-                            "$callbackBaseUrl/UNLOCK_CONNECTOR/callback/$locationId/$evseUid/$connectorId",
+                            responseUrl = "$callbackBaseUrl/UNLOCK_CONNECTOR/callback/$callbackReference",
                             locationId = locationId,
                             evseUid = evseUid,
                             connectorId = connectorId,

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspInterface.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspInterface.kt
@@ -4,29 +4,27 @@ import com.izivia.ocpi.toolkit.modules.commands.domain.CommandResult
 
 interface CommandEmspInterface {
     suspend fun postCallbackStartSession(
-        authorizationReference: String,
+        callbackReference: String,
         result: CommandResult,
     )
 
     suspend fun postCallbackStopSession(
-        sessionId: String,
+        callbackReference: String,
         result: CommandResult,
     )
 
     suspend fun postCallbackReserveNow(
-        reservationId: String,
+        callbackReference: String,
         result: CommandResult,
     )
 
     suspend fun postCallbackCancelReservation(
-        reservationId: String,
+        callbackReference: String,
         result: CommandResult,
     )
 
     suspend fun postCallbackUnlockConnector(
-        locationId: String,
-        evseId: String,
-        connectorId: String,
+        callbackReference: String,
         result: CommandResult,
     )
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspServer.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspServer.kt
@@ -30,12 +30,12 @@ class CommandEmspServer(
             method = HttpMethod.POST,
             path = basePathSegments + listOf(
                 FixedPathSegment("START_SESSION/callback"),
-                VariablePathSegment("authRef"),
+                VariablePathSegment("callbackReference"),
             ),
         ) { req ->
             req.respondNothing(timeProvider.now()) {
                 service.postCallbackStartSession(
-                    req.pathParam("authRef"),
+                    req.pathParam("callbackReference"),
                     result = mapper.readValue(req.body, CommandResult::class.java),
                 )
             }
@@ -45,12 +45,12 @@ class CommandEmspServer(
             method = HttpMethod.POST,
             path = basePathSegments + listOf(
                 FixedPathSegment("STOP_SESSION/callback"),
-                VariablePathSegment("sessionId"),
+                VariablePathSegment("callbackReference"),
             ),
         ) { req ->
             req.respondNothing(timeProvider.now()) {
                 service.postCallbackStopSession(
-                    req.pathParam("sessionId"),
+                    req.pathParam("callbackReference"),
                     result = mapper.readValue(req.body, CommandResult::class.java),
                 )
             }
@@ -60,12 +60,12 @@ class CommandEmspServer(
             method = HttpMethod.POST,
             path = basePathSegments + listOf(
                 FixedPathSegment("RESERVE_NOW/callback"),
-                VariablePathSegment("reservationId"),
+                VariablePathSegment("callbackReference"),
             ),
         ) { req ->
             req.respondNothing(timeProvider.now()) {
                 service.postCallbackReserveNow(
-                    req.pathParam("reservationId"),
+                    req.pathParam("callbackReference"),
                     result = mapper.readValue(req.body, CommandResult::class.java),
                 )
             }
@@ -75,12 +75,12 @@ class CommandEmspServer(
             method = HttpMethod.POST,
             path = basePathSegments + listOf(
                 FixedPathSegment("CANCEL_RESERVATION/callback"),
-                VariablePathSegment("reservationId"),
+                VariablePathSegment("callbackReference"),
             ),
         ) { req ->
             req.respondNothing(timeProvider.now()) {
                 service.postCallbackCancelReservation(
-                    req.pathParam("reservationId"),
+                    req.pathParam("callbackReference"),
                     result = mapper.readValue(req.body, CommandResult::class.java),
                 )
             }
@@ -90,16 +90,12 @@ class CommandEmspServer(
             method = HttpMethod.POST,
             path = basePathSegments + listOf(
                 FixedPathSegment("UNLOCK_CONNECTOR/callback"),
-                VariablePathSegment("locationId"),
-                VariablePathSegment("evseId"),
-                VariablePathSegment("connectorId"),
+                VariablePathSegment("callbackReference"),
             ),
         ) { req ->
             req.respondNothing(timeProvider.now()) {
                 service.postCallbackUnlockConnector(
-                    req.pathParam("locationId"),
-                    req.pathParam("evseId"),
-                    req.pathParam("connectorId"),
+                    req.pathParam("callbackReference"),
                     result = mapper.readValue(req.body, CommandResult::class.java),
                 )
             }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResponse.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResponse.kt
@@ -14,5 +14,5 @@ import com.izivia.ocpi.toolkit.modules.types.DisplayText
 data class CommandResponse(
     val result: CommandResponseType,
     val timeout: Int,
-    val message: List<DisplayText>,
+    val message: List<DisplayText>?,
 )

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResult.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/domain/CommandResult.kt
@@ -10,5 +10,5 @@ import com.izivia.ocpi.toolkit.modules.types.DisplayText
  */
 data class CommandResult(
     val result: CommandResultType,
-    val message: List<DisplayText>,
+    val message: List<DisplayText>?,
 )


### PR DESCRIPTION
messages field was incorrectly marked as obligatory
client interface now more clearly differentiates between data to be transferred and callback reference
specifically useful when wanting to stop a OCPI session, but using eMSP internal id as callback reference