### PR TITLE
fix #186: consider role when selecting endpoint url

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -12,8 +12,6 @@ import com.izivia.ocpi.toolkit.common.validation.validate
 import com.izivia.ocpi.toolkit.common.validation.validateLength
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
-import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.*
 import java.util.*
 
@@ -77,12 +75,12 @@ suspend fun PartnerRepository.buildAuthorizationHeader(
     if (allowTokenA) {
         getCredentialsClientToken(partnerId = partnerId)
             ?: getCredentialsTokenA(partnerId = partnerId)
-            ?: throw throw OcpiClientUnknownTokenException(
+            ?: throw OcpiClientUnknownTokenException(
                 "Could not find token A or client token associated with partner $partnerId",
             )
     } else {
         getCredentialsClientToken(partnerId = partnerId)
-            ?: throw throw OcpiClientUnknownTokenException(
+            ?: throw OcpiClientUnknownTokenException(
                 "Could not find client token associated with partner $partnerId",
             )
     }
@@ -348,14 +346,3 @@ suspend fun PartnerRepository.checkToken(
         throw HttpException(HttpStatus.UNAUTHORIZED, "Invalid server token (token A allowed: $allowTokenA)")
     }
 }
-
-suspend fun TransportClientBuilder.buildFor(
-    module: ModuleID,
-    partnerId: String,
-    partnerRepository: PartnerRepository,
-): TransportClient =
-    partnerRepository
-        .getEndpoints(partnerId = partnerId)
-        .find { it.identifier == module }
-        ?.let { build(baseUrl = it.url) }
-        ?: throw OcpiToolkitUnknownEndpointException(endpointName = module.name)

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiClientUtils.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiClientUtils.kt
@@ -1,7 +1,6 @@
 package com.izivia.ocpi.toolkit.common
 
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/TransportClientBuilder.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/TransportClientBuilder.kt
@@ -1,0 +1,8 @@
+package com.izivia.ocpi.toolkit.common
+
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
+import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
+import com.izivia.ocpi.toolkit.transport.BaseTransportClientBuilder
+
+/** alias for OCPI 2.2.1 specific TransportClientBuilder */
+interface TransportClientBuilder : BaseTransportClientBuilder<ModuleID, InterfaceRole>

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/cdr/CdrsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/cdr/CdrsCpoClient.kt
@@ -3,11 +3,11 @@ package com.izivia.ocpi.toolkit.modules.cdr
 import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.modules.cdr.domain.Cdr
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeObject
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 
@@ -24,9 +24,9 @@ class CdrsCpoClient(
 ) : CdrsEmspInterface<URL> {
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
-            module = ModuleID.cdrs,
             partnerId = partnerId,
-            partnerRepository = partnerRepository,
+            module = ModuleID.cdrs,
+            role = InterfaceRole.RECEIVER,
         )
 
     override suspend fun getCdr(param: URL): Cdr? =

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/cdr/CdrsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/cdr/CdrsEmspClient.kt
@@ -4,12 +4,11 @@ import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.modules.cdr.domain.Cdr
 import com.izivia.ocpi.toolkit.modules.cdr.domain.CdrPartial
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
-import org.apache.logging.log4j.LogManager
 import java.time.Instant
 
 class CdrsEmspClient(
@@ -18,13 +17,12 @@ class CdrsEmspClient(
     private val partnerRepository: PartnerRepository,
     private val ignoreInvalidListEntry: Boolean = false,
 ) : CdrsCpoInterface {
-    private val logger = LogManager.getLogger(CdrsEmspClient::class.java)
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
-            module = ModuleID.cdrs,
             partnerId = partnerId,
-            partnerRepository = partnerRepository,
+            module = ModuleID.cdrs,
+            role = InterfaceRole.SENDER,
         )
 
     override suspend fun getCdrs(

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/chargingProfiles/ChargingProfilesCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/chargingProfiles/ChargingProfilesCpoClient.kt
@@ -6,11 +6,11 @@ import com.izivia.ocpi.toolkit.modules.chargingProfiles.domain.ActiveChargingPro
 import com.izivia.ocpi.toolkit.modules.chargingProfiles.domain.ChargingProfileResult
 import com.izivia.ocpi.toolkit.modules.chargingProfiles.domain.ClearProfileResult
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeObject
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 
@@ -34,9 +34,9 @@ class ChargingProfilesCpoClient(
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
-            module = ModuleID.chargingprofiles,
             partnerId = partnerId,
-            partnerRepository = partnerRepository,
+            module = ModuleID.chargingprofiles,
+            role = InterfaceRole.SENDER,
         )
 
     suspend fun postCallbackActiveChargingProfile(

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/chargingProfiles/ChargingProfilesScspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/chargingProfiles/ChargingProfilesScspClient.kt
@@ -5,11 +5,11 @@ import com.izivia.ocpi.toolkit.modules.chargingProfiles.domain.ChargingProfile
 import com.izivia.ocpi.toolkit.modules.chargingProfiles.domain.ChargingProfileResponse
 import com.izivia.ocpi.toolkit.modules.chargingProfiles.domain.SetChargingProfile
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeObject
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 
@@ -22,9 +22,9 @@ class ChargingProfilesScspClient(
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
-            module = ModuleID.chargingprofiles,
             partnerId = partnerId,
-            partnerRepository = partnerRepository,
+            module = ModuleID.chargingprofiles,
+            role = InterfaceRole.RECEIVER,
         )
 
     suspend fun getActiveChargingProfile(

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoClient.kt
@@ -5,7 +5,6 @@ import com.izivia.ocpi.toolkit.modules.commands.domain.CommandResult
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeObject
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspClient.kt
@@ -4,11 +4,11 @@ import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.modules.commands.domain.*
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.tokens.domain.Token
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeObject
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 import java.time.Instant
@@ -22,9 +22,9 @@ class CommandEmspClient(
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
-            module = ModuleID.commands,
             partnerId = partnerId,
-            partnerRepository = partnerRepository,
+            module = ModuleID.commands,
+            role = InterfaceRole.RECEIVER,
         )
 
     suspend fun postStartSession(

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsClientService.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsClientService.kt
@@ -1,9 +1,6 @@
 package com.izivia.ocpi.toolkit.modules.credentials.services
 
-import com.izivia.ocpi.toolkit.common.OcpiClientGenericException
-import com.izivia.ocpi.toolkit.common.OcpiClientInvalidParametersException
-import com.izivia.ocpi.toolkit.common.OcpiServerUnsupportedVersionException
-import com.izivia.ocpi.toolkit.common.generateUUIDv4Token
+import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.modules.credentials.CredentialsClient
 import com.izivia.ocpi.toolkit.modules.credentials.domain.Credentials
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.CredentialsRoleRepository
@@ -14,7 +11,6 @@ import com.izivia.ocpi.toolkit.modules.versions.domain.Endpoint
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.modules.versions.domain.parseVersionNumber
 import com.izivia.ocpi.toolkit.modules.versions.repositories.VersionsRepository
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 
 /**
  * Automates authentification process

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
@@ -8,7 +8,6 @@ import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepositor
 import com.izivia.ocpi.toolkit.modules.versions.domain.Version
 import com.izivia.ocpi.toolkit.modules.versions.domain.VersionDetails
 import com.izivia.ocpi.toolkit.modules.versions.domain.VersionNumber
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/PartnerProvider.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/PartnerProvider.kt
@@ -1,0 +1,24 @@
+package com.izivia.ocpi.toolkit.modules.credentials.services
+
+import com.izivia.ocpi.toolkit.common.OcpiToolkitUnknownEndpointException
+import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
+import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
+import com.izivia.ocpi.toolkit.transport.PartnerProviderInterface
+
+class PartnerProvider(
+    private val partnerRepository: PartnerRepository,
+) : PartnerProviderInterface<ModuleID, InterfaceRole> {
+
+    override suspend fun getEndpointUrl(
+        partnerId: String,
+        moduleId: ModuleID,
+        role: InterfaceRole,
+    ): String {
+        return partnerRepository
+            .getEndpoints(partnerId = partnerId)
+            .find { it.identifier == moduleId && it.role == role }
+            ?.url
+            ?: throw OcpiToolkitUnknownEndpointException(endpointName = moduleId.name)
+    }
+}

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/hubclientinfo/HubClientInfoReceiverClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/hubclientinfo/HubClientInfoReceiverClient.kt
@@ -3,9 +3,9 @@ package com.izivia.ocpi.toolkit.modules.hubclientinfo
 import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.hubclientinfo.domain.ClientInfo
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 import java.time.Instant
@@ -18,9 +18,9 @@ class HubClientInfoReceiverClient(
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
-            module = ModuleID.hubclientinfo,
             partnerId = partnerId,
-            partnerRepository = partnerRepository,
+            module = ModuleID.hubclientinfo,
+            role = InterfaceRole.SENDER,
         )
 
     override suspend fun getAll(

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/hubclientinfo/HubClientInfoSenderClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/hubclientinfo/HubClientInfoSenderClient.kt
@@ -3,11 +3,11 @@ package com.izivia.ocpi.toolkit.modules.hubclientinfo
 import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.hubclientinfo.domain.ClientInfo
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeObject
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 
@@ -19,9 +19,9 @@ class HubClientInfoSenderClient(
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
-            module = ModuleID.hubclientinfo,
             partnerId = partnerId,
-            partnerRepository = partnerRepository,
+            module = ModuleID.hubclientinfo,
+            role = InterfaceRole.RECEIVER,
         )
 
     override suspend fun get(

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
@@ -3,11 +3,11 @@ package com.izivia.ocpi.toolkit.modules.locations
 import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.locations.domain.*
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeObject
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 
@@ -25,9 +25,9 @@ class LocationsCpoClient(
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
-            module = ModuleID.locations,
             partnerId = partnerId,
-            partnerRepository = partnerRepository,
+            module = ModuleID.locations,
+            role = InterfaceRole.RECEIVER,
         )
 
     override suspend fun getLocation(

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
@@ -6,9 +6,9 @@ import com.izivia.ocpi.toolkit.modules.locations.domain.Connector
 import com.izivia.ocpi.toolkit.modules.locations.domain.Evse
 import com.izivia.ocpi.toolkit.modules.locations.domain.Location
 import com.izivia.ocpi.toolkit.modules.locations.domain.LocationPartial
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 import java.time.Instant
@@ -28,9 +28,9 @@ class LocationsEmspClient(
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
-            module = ModuleID.locations,
             partnerId = partnerId,
-            partnerRepository = partnerRepository,
+            module = ModuleID.locations,
+            role = InterfaceRole.SENDER,
         )
 
     override suspend fun getLocations(

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsCpoClient.kt
@@ -4,11 +4,11 @@ import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.sessions.domain.Session
 import com.izivia.ocpi.toolkit.modules.sessions.domain.SessionPartial
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeObject
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 
@@ -25,9 +25,9 @@ class SessionsCpoClient(
 ) : SessionsEmspInterface {
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
-            module = ModuleID.sessions,
             partnerId = partnerId,
-            partnerRepository = partnerRepository,
+            module = ModuleID.sessions,
+            role = InterfaceRole.RECEIVER,
         )
 
     override suspend fun getSession(

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsEmspClient.kt
@@ -6,11 +6,11 @@ import com.izivia.ocpi.toolkit.modules.sessions.domain.ChargingPreferences
 import com.izivia.ocpi.toolkit.modules.sessions.domain.ChargingPreferencesResponseType
 import com.izivia.ocpi.toolkit.modules.sessions.domain.Session
 import com.izivia.ocpi.toolkit.modules.sessions.domain.SessionPartial
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeObject
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 import java.time.Instant
@@ -29,9 +29,9 @@ class SessionsEmspClient(
 ) : SessionsCpoInterface {
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
-            module = ModuleID.sessions,
             partnerId = partnerId,
-            partnerRepository = partnerRepository,
+            module = ModuleID.sessions,
+            role = InterfaceRole.SENDER,
         )
 
     override suspend fun getSessions(

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tariff/TariffCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tariff/TariffCpoClient.kt
@@ -4,11 +4,11 @@ import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.tariff.domain.Tariff
 import com.izivia.ocpi.toolkit.modules.tariff.domain.TariffPartial
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeObject
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 
@@ -20,9 +20,9 @@ class TariffCpoClient(
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
-            module = ModuleID.tariffs,
             partnerId = partnerId,
-            partnerRepository = partnerRepository,
+            module = ModuleID.tariffs,
+            role = InterfaceRole.RECEIVER,
         )
 
     override suspend fun getTariff(

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tariff/TariffEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tariff/TariffEmspClient.kt
@@ -4,9 +4,9 @@ import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.tariff.domain.Tariff
 import com.izivia.ocpi.toolkit.modules.tariff.domain.TariffPartial
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 import java.time.Instant
@@ -20,9 +20,9 @@ class TariffEmspClient(
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
-            module = ModuleID.tariffs,
             partnerId = partnerId,
-            partnerRepository = partnerRepository,
+            module = ModuleID.tariffs,
+            role = InterfaceRole.SENDER,
         )
 
     override suspend fun getTariffs(

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
@@ -3,11 +3,11 @@ package com.izivia.ocpi.toolkit.modules.tokens
 import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.tokens.domain.*
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeObject
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 import java.time.Instant
@@ -26,9 +26,9 @@ class TokensCpoClient(
 ) : TokensEmspInterface {
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
-            module = ModuleID.tokens,
             partnerId = partnerId,
-            partnerRepository = partnerRepository,
+            module = ModuleID.tokens,
+            role = InterfaceRole.SENDER,
         )
 
     override suspend fun getTokens(

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
@@ -5,11 +5,11 @@ import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepositor
 import com.izivia.ocpi.toolkit.modules.tokens.domain.Token
 import com.izivia.ocpi.toolkit.modules.tokens.domain.TokenPartial
 import com.izivia.ocpi.toolkit.modules.tokens.domain.TokenType
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeObject
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 
@@ -27,9 +27,9 @@ class TokensEmspClient(
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
-            module = ModuleID.tokens,
             partnerId = partnerId,
-            partnerRepository = partnerRepository,
+            module = ModuleID.tokens,
+            role = InterfaceRole.RECEIVER,
         )
 
     override suspend fun getToken(

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionDetailsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionDetailsClient.kt
@@ -1,12 +1,8 @@
 package com.izivia.ocpi.toolkit.modules.versions
 
-import com.izivia.ocpi.toolkit.common.OcpiToolkitUnknownEndpointException
-import com.izivia.ocpi.toolkit.common.authenticate
-import com.izivia.ocpi.toolkit.common.parseResult
-import com.izivia.ocpi.toolkit.common.withRequiredHeaders
+import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.versions.domain.VersionDetails
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsClient.kt
@@ -1,12 +1,8 @@
 package com.izivia.ocpi.toolkit.modules.versions
 
-import com.izivia.ocpi.toolkit.common.OcpiToolkitUnknownEndpointException
-import com.izivia.ocpi.toolkit.common.authenticate
-import com.izivia.ocpi.toolkit.common.parseResultList
-import com.izivia.ocpi.toolkit.common.withRequiredHeaders
+import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.versions.domain.Version
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspClientGetLocationsTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspClientGetLocationsTest.kt
@@ -14,7 +14,6 @@ import com.izivia.ocpi.toolkit.serialization.OcpiSerializer
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeOcpiResponseList
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
@@ -121,6 +120,14 @@ private inline fun <reified T> mockSearchResult(data: List<T>) =
 class MockHttpTransportClientBuilder(
     private val handler: HttpHandler,
 ) : TransportClientBuilder {
+    override suspend fun buildFor(
+        partnerId: String,
+        module: ModuleID,
+        role: InterfaceRole,
+    ): TransportClient {
+        return build("")
+    }
+
     override fun build(baseUrl: String): TransportClient =
         Http4kTransportClient(handler)
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Http4kTransportClientBuilder.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Http4kTransportClientBuilder.kt
@@ -1,9 +1,14 @@
 package com.izivia.ocpi.toolkit.samples.common
 
+import com.izivia.ocpi.toolkit.common.TransportClientBuilder
+import com.izivia.ocpi.toolkit.modules.credentials.services.PartnerProvider
+import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
+import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
+import com.izivia.ocpi.toolkit.transport.AbstractTransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.TransportClient
-import com.izivia.ocpi.toolkit.transport.TransportClientBuilder
 
-class Http4kTransportClientBuilder : TransportClientBuilder {
-    override fun build(baseUrl: String): TransportClient =
-        Http4kTransportClient(baseUrl)
+class Http4kTransportClientBuilder(
+    partnerProvider: PartnerProvider,
+) : TransportClientBuilder, AbstractTransportClientBuilder<ModuleID, InterfaceRole>(partnerProvider) {
+    override fun build(baseUrl: String): TransportClient = Http4kTransportClient(baseUrl)
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/VersionsCacheRepository.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/VersionsCacheRepository.kt
@@ -25,6 +25,11 @@ class VersionsCacheRepository(
                     role = InterfaceRole.RECEIVER,
                     url = "$baseUrl/${VersionNumber.V2_2_1.value}/locations",
                 ),
+                Endpoint(
+                    identifier = ModuleID.locations,
+                    role = InterfaceRole.SENDER,
+                    url = "$baseUrl/${VersionNumber.V2_2_1.value}/locations",
+                ),
             ),
         ).takeIf { versionNumber.value == it.version }
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsReceiver.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsReceiver.kt
@@ -6,6 +6,7 @@ import com.izivia.ocpi.toolkit.modules.credentials.domain.CredentialRole
 import com.izivia.ocpi.toolkit.modules.credentials.domain.Role
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.CredentialsRoleRepository
 import com.izivia.ocpi.toolkit.modules.credentials.services.CredentialsServerService
+import com.izivia.ocpi.toolkit.modules.credentials.services.PartnerProvider
 import com.izivia.ocpi.toolkit.modules.credentials.services.RequiredEndpoints
 import com.izivia.ocpi.toolkit.modules.locations.domain.BusinessDetails
 import com.izivia.ocpi.toolkit.modules.versions.VersionsServer
@@ -51,7 +52,7 @@ fun main() {
                         ),
                     )
                 },
-                transportClientBuilder = Http4kTransportClientBuilder(),
+                transportClientBuilder = Http4kTransportClientBuilder(PartnerProvider(receiverPlatformRepository)),
                 serverVersionsUrlProvider = { receiverVersionsUrl },
                 requiredEndpoints = requiredOtherPartEndpoints,
             ),

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsSender.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/credentials/CredentialsSender.kt
@@ -5,6 +5,7 @@ import com.izivia.ocpi.toolkit.modules.credentials.domain.CredentialRole
 import com.izivia.ocpi.toolkit.modules.credentials.domain.Role
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.CredentialsRoleRepository
 import com.izivia.ocpi.toolkit.modules.credentials.services.CredentialsClientService
+import com.izivia.ocpi.toolkit.modules.credentials.services.PartnerProvider
 import com.izivia.ocpi.toolkit.modules.credentials.services.RequiredEndpoints
 import com.izivia.ocpi.toolkit.modules.locations.domain.BusinessDetails
 import com.izivia.ocpi.toolkit.modules.versions.VersionsServer
@@ -68,7 +69,7 @@ fun main() {
             )
         },
         partnerId = receiverVersionsUrl,
-        transportClientBuilder = Http4kTransportClientBuilder(),
+        transportClientBuilder = Http4kTransportClientBuilder(PartnerProvider(senderPlatformRepository)),
         requiredEndpoints = RequiredEndpoints(receiver = listOf(ModuleID.credentials)),
     )
 

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsCpoClient.kt
@@ -1,5 +1,6 @@
 package com.izivia.ocpi.toolkit.samples.locations
 
+import com.izivia.ocpi.toolkit.modules.credentials.services.PartnerProvider
 import com.izivia.ocpi.toolkit.modules.locations.LocationsCpoClient
 import com.izivia.ocpi.toolkit.samples.common.Http4kTransportClientBuilder
 import kotlinx.coroutines.runBlocking
@@ -10,7 +11,7 @@ import kotlinx.coroutines.runBlocking
 fun main() {
     // We instantiate the clients that we want to use
     val locationsCpoClient = LocationsCpoClient(
-        transportClientBuilder = Http4kTransportClientBuilder(),
+        transportClientBuilder = Http4kTransportClientBuilder(PartnerProvider(DUMMY_PLATFORM_REPOSITORY)),
         partnerId = emspServerVersionsUrl,
         partnerRepository = DUMMY_PLATFORM_REPOSITORY,
     )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsEmspClient.kt
@@ -1,5 +1,6 @@
 package com.izivia.ocpi.toolkit.samples.locations
 
+import com.izivia.ocpi.toolkit.modules.credentials.services.PartnerProvider
 import com.izivia.ocpi.toolkit.modules.locations.LocationsEmspClient
 import com.izivia.ocpi.toolkit.samples.common.Http4kTransportClientBuilder
 import kotlinx.coroutines.runBlocking
@@ -10,7 +11,7 @@ import kotlinx.coroutines.runBlocking
 fun main() {
     // We instantiate the clients that we want to use
     val locationsEmspClient = LocationsEmspClient(
-        transportClientBuilder = Http4kTransportClientBuilder(),
+        transportClientBuilder = Http4kTransportClientBuilder(PartnerProvider(DUMMY_PLATFORM_REPOSITORY)),
         partnerId = cpoServerVersionsUrl,
         partnerRepository = DUMMY_PLATFORM_REPOSITORY,
     )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/LocationsIntegrationTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/LocationsIntegrationTest.kt
@@ -3,6 +3,7 @@ package com.izivia.ocpi.toolkit.tests.integration
 import com.izivia.ocpi.toolkit.common.Header
 import com.izivia.ocpi.toolkit.common.TestWithSerializerProviders
 import com.izivia.ocpi.toolkit.common.context.RequestMessageRoutingHeaders
+import com.izivia.ocpi.toolkit.modules.credentials.services.PartnerProvider
 import com.izivia.ocpi.toolkit.modules.locations.LocationsCpoServer
 import com.izivia.ocpi.toolkit.modules.locations.LocationsEmspClient
 import com.izivia.ocpi.toolkit.modules.locations.domain.Location
@@ -79,7 +80,7 @@ class LocationsIntegrationTest : BaseServerIntegrationTest(), TestWithSerializer
         }
 
         val locationsEmspClient = LocationsEmspClient(
-            transportClientBuilder = Http4kTransportClientBuilder(),
+            transportClientBuilder = Http4kTransportClientBuilder(PartnerProvider(partnerRepo)),
             partnerId = cpoServerVersionsUrl,
             partnerRepository = partnerRepo,
         )

--- a/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/PartnerProviderInterface.kt
+++ b/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/PartnerProviderInterface.kt
@@ -1,0 +1,5 @@
+package com.izivia.ocpi.toolkit.transport
+
+interface PartnerProviderInterface<M, R> {
+    suspend fun getEndpointUrl(partnerId: String, moduleId: M, role: R): String
+}

--- a/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/TransportClient.kt
+++ b/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/TransportClient.kt
@@ -24,7 +24,3 @@ interface TransportClient {
      */
     suspend fun generateRequestId(): String = UUID.randomUUID().toString()
 }
-
-interface TransportClientBuilder {
-    fun build(baseUrl: String): TransportClient
-}

--- a/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/TransportClientBuilder.kt
+++ b/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/TransportClientBuilder.kt
@@ -1,0 +1,14 @@
+package com.izivia.ocpi.toolkit.transport
+
+interface BaseTransportClientBuilder<M, R> {
+    suspend fun buildFor(partnerId: String, module: M, role: R): TransportClient
+    fun build(baseUrl: String): TransportClient
+}
+
+abstract class AbstractTransportClientBuilder<M, R>(
+    protected val partnerProvider: PartnerProviderInterface<M, R>,
+) : BaseTransportClientBuilder<M, R> {
+    override suspend fun buildFor(partnerId: String, module: M, role: R): TransportClient {
+        return build(partnerProvider.getEndpointUrl(partnerId, module, role))
+    }
+}


### PR DESCRIPTION
- move transport client builder functions into transport module
- adds version independent interfaces for reusability and access to partner repository
- ocpi version specific version of TransportClientBuilder keeps code changes in implementations to a minimum 
  - implementors need to change import statement from transport to common