### PR TITLE
feat(transport) #18: abstract transport client adds required headers

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpRequest.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpRequest.kt
@@ -1,9 +1,9 @@
 package com.izivia.ocpi.toolkit.common
 
-import com.izivia.ocpi.toolkit.common.context.currentResponseMessageRoutingHeadersOrNull
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeOcpiResponse
 import com.izivia.ocpi.toolkit.serialization.serializeOcpiResponseList
+import com.izivia.ocpi.toolkit.transport.context.currentResponseMessageRoutingHeadersOrNull
 import com.izivia.ocpi.toolkit.transport.domain.HttpException
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 import com.izivia.ocpi.toolkit.transport.domain.HttpResponse

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpUtils.kt
@@ -4,18 +4,14 @@ import com.izivia.ocpi.toolkit.common.Header.OCPI_FROM_COUNTRY_CODE
 import com.izivia.ocpi.toolkit.common.Header.OCPI_FROM_PARTY_ID
 import com.izivia.ocpi.toolkit.common.Header.OCPI_TO_COUNTRY_CODE
 import com.izivia.ocpi.toolkit.common.Header.OCPI_TO_PARTY_ID
-import com.izivia.ocpi.toolkit.common.context.RequestMessageRoutingHeaders
-import com.izivia.ocpi.toolkit.common.context.ResponseMessageRoutingHeaders
-import com.izivia.ocpi.toolkit.common.context.TokenHeader
-import com.izivia.ocpi.toolkit.common.context.currentRequestMessageRoutingHeadersOrNull
 import com.izivia.ocpi.toolkit.common.validation.validate
 import com.izivia.ocpi.toolkit.common.validation.validateLength
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
+import com.izivia.ocpi.toolkit.transport.context.RequestMessageRoutingHeaders
+import com.izivia.ocpi.toolkit.transport.context.ResponseMessageRoutingHeaders
+import com.izivia.ocpi.toolkit.transport.decodeBase64
 import com.izivia.ocpi.toolkit.transport.domain.*
-import java.util.*
-
-typealias AuthenticatedHttpRequest = HttpRequest
 
 object Header {
     const val AUTHORIZATION = "Authorization"
@@ -46,100 +42,6 @@ fun Map<String, String>.validateMessageRoutingHeaders() {
 }
 
 /**
- * Encode a string in base64, also @see String#decodeBase64()
- */
-fun String.encodeBase64(): String = Base64.getEncoder().encodeToString(this.encodeToByteArray())
-
-/**
- * Decodes a base64-encoded string, also @see String#encodeBase64()
- */
-fun String.decodeBase64(): String = Base64.getDecoder().decode(this).decodeToString()
-
-/**
- * Creates the authorization header from the given token
- */
-fun authorizationHeader(token: String): Pair<String, String> = Header.AUTHORIZATION to "Token ${token.encodeBase64()}"
-
-/**
- * Creates the authorization header by taking the client token (or the token A if allowed) in the partner repository
- *
- * @receiver PlatformRepository used to retrieve tokens
- * @param partnerId partner identifier
- * @param allowTokenA only true when called on versions / credentials module
- * @return Pair<String, String>
- */
-suspend fun PartnerRepository.buildAuthorizationHeader(
-    partnerId: String,
-    allowTokenA: Boolean = false,
-): Pair<String, String> =
-    if (allowTokenA) {
-        getCredentialsClientToken(partnerId = partnerId)
-            ?: getCredentialsTokenA(partnerId = partnerId)
-            ?: throw OcpiClientUnknownTokenException(
-                "Could not find token A or client token associated with partner $partnerId",
-            )
-    } else {
-        getCredentialsClientToken(partnerId = partnerId)
-            ?: throw OcpiClientUnknownTokenException(
-                "Could not find client token associated with partner $partnerId",
-            )
-    }
-        .let { token -> authorizationHeader(token = token) }
-
-/**
- * Adds the authorization header to the request by taking the client token (or the token A if allowed) in the partner
- * repository.
- *
- * @param partnerRepository use to retrieve tokens
- * @param partnerId partner identifier
- * @param allowTokenA only true when called on versions / credentials module
- */
-suspend fun HttpRequest.authenticate(
-    partnerRepository: PartnerRepository,
-    partnerId: String,
-    allowTokenA: Boolean = false,
-): AuthenticatedHttpRequest =
-    withHeaders(
-        headers = headers.plus(
-            partnerRepository.buildAuthorizationHeader(
-                partnerId = partnerId,
-                allowTokenA = allowTokenA,
-            ),
-        ),
-    )
-
-/**
- * Adds the authentification header to the request.
- *
- * @param token the token to use to authenticate
- */
-fun HttpRequest.authenticate(token: String): AuthenticatedHttpRequest =
-    withHeaders(headers = headers.plus(authorizationHeader(token = token)))
-
-/**
- * It adds Content-Type header as "application/json" if the body is not null.
- */
-private fun HttpRequest.withContentTypeHeaderIfNeeded(): HttpRequest =
-    if (body != null) {
-        withHeaders(headers = headers.plus(Header.CONTENT_TYPE to ContentType.APPLICATION_JSON))
-    } else {
-        this
-    }
-
-/**
- * It adds message routing header if they are set in the current coroutine context
- */
-private suspend fun HttpRequest.withRequestMessageRoutingHeadersIfPresent(): HttpRequest {
-    val requestMessageRoutingHeaders = currentRequestMessageRoutingHeadersOrNull()
-
-    return if (requestMessageRoutingHeaders != null) {
-        withHeaders(headers = headers.plus(requestMessageRoutingHeaders.httpHeaders()))
-    } else {
-        this
-    }
-}
-
-/**
  * It builds MessageRoutingHeaders from the headers of the request.
  */
 fun HttpRequest.messageRoutingHeaders(): RequestMessageRoutingHeaders =
@@ -150,19 +52,6 @@ fun HttpRequest.messageRoutingHeaders(): RequestMessageRoutingHeaders =
         fromCountryCode = headers.getByNormalizedKey(OCPI_FROM_COUNTRY_CODE),
     )
 
-/**
- * It builds headers from a ResponseMessageRoutingHeaders
- */
-private fun RequestMessageRoutingHeaders.httpHeaders(): Map<String, String> =
-    mapOf(
-        OCPI_TO_PARTY_ID to toPartyId,
-        OCPI_TO_COUNTRY_CODE to toCountryCode,
-        OCPI_FROM_PARTY_ID to fromPartyId,
-        OCPI_FROM_COUNTRY_CODE to fromCountryCode,
-    )
-        .filter { it.value != null }
-        .mapValues { it.value!! }
-
 fun ResponseMessageRoutingHeaders.httpHeaders(): Map<String, String> =
     mapOf(
         OCPI_TO_PARTY_ID to toPartyId,
@@ -172,98 +61,6 @@ fun ResponseMessageRoutingHeaders.httpHeaders(): Map<String, String> =
     )
         .filter { it.value != null }
         .mapValues { it.value!! }
-
-/**
- * It builds TokenHeader from the header of the request (it can be used in coroutine context)
- */
-fun HttpRequest.extractTokenHeader(): TokenHeader =
-    TokenHeader(
-        token = parseAuthorizationHeader(),
-    )
-
-/**
- * For debugging issues, OCPI implementations are required to include unique IDs via HTTP headers in every
- * request/response.
- *
- * - X-Request-ID: Every request SHALL contain a unique request ID, the response to this request SHALL contain the same
- * ID.
- * - X-Correlation-ID: Every request/response SHALL contain a unique correlation ID, every response to this request
- * SHALL contain the same ID.
- *
- * Moreover, for requests, Content-Type SHALL be set to application/json for any request that contains a
- * message body: POST, PUT and PATCH. When no body is present, probably in a GET or DELETE, then the Content-Type
- * header MAY be omitted.
- *
- * This method should be called when doing the first request from a client.
- *
- * Dev note: When the server does a request (not a response), it must keep the same X-Correlation-ID but generate a new
- * X-Request-ID. So don't call this method in that case.
- */
-suspend fun HttpRequest.withRequiredHeaders(
-    requestId: String,
-    correlationId: String,
-): HttpRequest =
-    withHeaders(
-        headers = headers
-            .plus(Header.X_REQUEST_ID to requestId)
-            .plus(Header.X_CORRELATION_ID to correlationId),
-    )
-        .withContentTypeHeaderIfNeeded()
-        .withRequestMessageRoutingHeadersIfPresent()
-
-/**
- * For debugging issues, OCPI implementations are required to include unique IDs via HTTP headers in every
- * request/response
- *
- * - X-Request-ID: Every request SHALL contain a unique request ID, the response to this request SHALL contain the same
- * ID.
- * - X-Correlation-ID: Every request/response SHALL contain a unique correlation ID, every response to this request
- * SHALL contain the same ID.
- *
- * Moreover, for requests, Content-Type SHALL be set to application/json for any request that contains a
- * message body: POST, PUT and PATCH. When no body is present, probably in a GET or DELETE, then the Content-Type
- * header MAY be omitted.
- *
- * This method should be called when doing the a request from a server.
- *
- * @param headers Headers of the caller. It will re-use the X-Correlation-ID header and regenerate X-Request-ID
- */
-fun HttpRequest.withUpdatedRequiredHeaders(
-    headers: Map<String, String>,
-    generatedRequestId: String,
-): HttpRequest =
-    withHeaders(
-        headers = headers
-            .plus(Header.X_REQUEST_ID to generatedRequestId) // it replaces existing X_REQUEST_ID header
-            .plus(
-                Header.X_CORRELATION_ID to (
-                    headers.getByNormalizedKey(Header.X_CORRELATION_ID)
-                        ?: "error - could not get ${Header.X_CORRELATION_ID} header"
-                    ),
-            ),
-    ).withContentTypeHeaderIfNeeded()
-
-/**
- * For debugging issues, OCPI implementations are required to include unique IDs via HTTP headers in every
- * request/response
- *
- * - X-Request-ID: Every request SHALL contain a unique request ID, the response to this request SHALL contain the same
- * ID.
- * - X-Correlation-ID: Every request/response SHALL contain a unique correlation ID, every response to this request
- * SHALL contain the same ID.
- *
- * This method should be called when responding to a request from a client.
- */
-fun HttpRequest.getDebugHeaders() = listOfNotNull(
-    getHeader(Header.X_REQUEST_ID)?.let { Header.X_REQUEST_ID to it },
-    getHeader(Header.X_CORRELATION_ID)?.let { Header.X_CORRELATION_ID to it },
-).toMap()
-
-/**
- * Returns the value of a header by its key. The key is not case-sensitive.
- */
-fun HttpRequest.getHeader(key: String): String? =
-    headers.getByNormalizedKey(key)
 
 /**
  * Returns the value of a header by its key. The key is not case-sensitive.
@@ -295,7 +92,7 @@ fun HttpRequest.parseAuthorizationHeader() = getHeader(Header.AUTHORIZATION)
     ?.let {
         try {
             it.decodeBase64()
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             throw HttpException(HttpStatus.BAD_REQUEST, "${Header.AUTHORIZATION} token cannot be decoded")
         }
     }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiClientUtils.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/OcpiClientUtils.kt
@@ -1,27 +1,20 @@
 package com.izivia.ocpi.toolkit.common
 
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 
 suspend inline fun <reified T, reified P : Partial<T>> getNextPage(
     transportClientBuilder: TransportClientBuilder,
     partnerId: String,
-    partnerRepository: PartnerRepository,
     previousResponse: SearchResult<T>,
     ignoreInvalidListEntry: Boolean = false,
 ): SearchResult<T>? =
     previousResponse.nextPageUrl?.let { nextPageUrl ->
-        with(transportClientBuilder.build(nextPageUrl)) {
+        with(transportClientBuilder.buildFor(partnerId, nextPageUrl)) {
             send(
                 HttpRequest(
                     method = HttpMethod.GET,
-                )
-                    .withRequiredHeaders(
-                        requestId = generateRequestId(),
-                        correlationId = generateCorrelationId(),
-                    )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             ).let { res ->
                 if (ignoreInvalidListEntry) {
                     res.parseSearchResultIgnoringInvalid<T, P>(previousResponse.offset)

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/cdr/CdrsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/cdr/CdrsCpoClient.kt
@@ -2,7 +2,6 @@ package com.izivia.ocpi.toolkit.modules.cdr
 
 import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.modules.cdr.domain.Cdr
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.serialization.mapper
@@ -15,12 +14,10 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
  * Sends calls to an eMSP server
  * @property transportClientBuilder used to build transport client
  * @property partnerId used to know which partner to communicate with
- * @property partnerRepository used to get information about the partner (endpoint, token)
  */
 class CdrsCpoClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val partnerId: String,
-    private val partnerRepository: PartnerRepository,
 ) : CdrsEmspInterface<URL> {
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
@@ -30,16 +27,12 @@ class CdrsCpoClient(
         )
 
     override suspend fun getCdr(param: URL): Cdr? =
-        with(transportClientBuilder.build(param)) {
+        with(transportClientBuilder.buildFor(partnerId, param)) {
             send(
                 HttpRequest(
                     method = HttpMethod.GET,
                     path = "/",
-                ).withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             )
                 .parseOptionalResult()
         }
@@ -50,11 +43,7 @@ class CdrsCpoClient(
                 HttpRequest(
                     method = HttpMethod.POST,
                     body = mapper.serializeObject(cdr),
-                ).withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             )
                 .also {
                     // this will check response for errors and throw exceptions where applicable

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/cdr/CdrsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/cdr/CdrsEmspClient.kt
@@ -3,7 +3,6 @@ package com.izivia.ocpi.toolkit.modules.cdr
 import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.modules.cdr.domain.Cdr
 import com.izivia.ocpi.toolkit.modules.cdr.domain.CdrPartial
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.transport.TransportClient
@@ -14,7 +13,6 @@ import java.time.Instant
 class CdrsEmspClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val partnerId: String,
-    private val partnerRepository: PartnerRepository,
     private val ignoreInvalidListEntry: Boolean = false,
 ) : CdrsCpoInterface {
 
@@ -41,11 +39,7 @@ class CdrsEmspClient(
                         "offset" to offset.toString(),
                         limit?.let { "limit" to it.toString() },
                     ).toMap(),
-                ).withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             ).let { res ->
                 if (ignoreInvalidListEntry) {
                     res.parseSearchResultIgnoringInvalid<Cdr, CdrPartial>(offset)
@@ -60,7 +54,6 @@ class CdrsEmspClient(
     ): SearchResult<Cdr>? = getNextPage<Cdr, CdrPartial>(
         transportClientBuilder = transportClientBuilder,
         partnerId = partnerId,
-        partnerRepository = partnerRepository,
         previousResponse = previousResponse,
         ignoreInvalidListEntry = ignoreInvalidListEntry,
     )

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/chargingProfiles/ChargingProfilesCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/chargingProfiles/ChargingProfilesCpoClient.kt
@@ -1,11 +1,12 @@
 package com.izivia.ocpi.toolkit.modules.chargingProfiles
 
-import com.izivia.ocpi.toolkit.common.*
+import com.izivia.ocpi.toolkit.common.CiString
+import com.izivia.ocpi.toolkit.common.TransportClientBuilder
+import com.izivia.ocpi.toolkit.common.parseResultOrNull
 import com.izivia.ocpi.toolkit.modules.chargingProfiles.domain.ActiveChargingProfile
 import com.izivia.ocpi.toolkit.modules.chargingProfiles.domain.ActiveChargingProfileResult
 import com.izivia.ocpi.toolkit.modules.chargingProfiles.domain.ChargingProfileResult
 import com.izivia.ocpi.toolkit.modules.chargingProfiles.domain.ClearProfileResult
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.serialization.mapper
@@ -19,18 +20,16 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
  *
  * @property transportClientBuilder used to build transport client
  * @property partnerId used to know which partner to communicate with
- * @property partnerRepository used to get information about the partner (endpoint, token)
  * @property callbackBaseUrl used to build the callback URL sent to the other partner
  */
 class ChargingProfilesCpoClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val partnerId: String,
-    private val partnerRepository: PartnerRepository,
     private val callbackBaseUrl: String,
 ) {
 
-    private fun buildCallbackTransport(): TransportClient =
-        transportClientBuilder.build(callbackBaseUrl)
+    private suspend fun buildCallbackTransport(): TransportClient =
+        transportClientBuilder.buildFor(partnerId, callbackBaseUrl)
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
@@ -48,12 +47,7 @@ class ChargingProfilesCpoClient(
                 method = HttpMethod.POST,
                 path = responseUrl,
                 body = mapper.serializeObject(result),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseResultOrNull<String>()
     }
@@ -67,12 +61,7 @@ class ChargingProfilesCpoClient(
                 method = HttpMethod.POST,
                 path = responseUrl,
                 body = mapper.serializeObject(result),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseResultOrNull<String>()
     }
@@ -86,12 +75,7 @@ class ChargingProfilesCpoClient(
                 method = HttpMethod.POST,
                 path = responseUrl,
                 body = mapper.serializeObject(result),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseResultOrNull<String>()
     }
@@ -105,12 +89,7 @@ class ChargingProfilesCpoClient(
                 method = HttpMethod.PUT,
                 path = "/$sessionId",
                 body = mapper.serializeObject(activeChargingProfile),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseResultOrNull<String>()
     }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/chargingProfiles/ChargingProfilesScspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/chargingProfiles/ChargingProfilesScspClient.kt
@@ -1,10 +1,12 @@
 package com.izivia.ocpi.toolkit.modules.chargingProfiles
 
-import com.izivia.ocpi.toolkit.common.*
+import com.izivia.ocpi.toolkit.common.CiString
+import com.izivia.ocpi.toolkit.common.TransportClientBuilder
+import com.izivia.ocpi.toolkit.common.URL
+import com.izivia.ocpi.toolkit.common.parseResult
 import com.izivia.ocpi.toolkit.modules.chargingProfiles.domain.ChargingProfile
 import com.izivia.ocpi.toolkit.modules.chargingProfiles.domain.ChargingProfileResponse
 import com.izivia.ocpi.toolkit.modules.chargingProfiles.domain.SetChargingProfile
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.serialization.mapper
@@ -16,7 +18,6 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 class ChargingProfilesScspClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val partnerId: String,
-    private val partnerRepository: PartnerRepository,
     private val callbackBaseUrl: URL,
 ) {
 
@@ -41,12 +42,7 @@ class ChargingProfilesScspClient(
                     "response_url" to "$callbackBaseUrl/" +
                         "${ChargingProfilesScspServer.ACTIVE_CHARGING_PROFILE_CALLBACK_URL}/$requestId",
                 ),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseResult()
     }
@@ -67,12 +63,7 @@ class ChargingProfilesScspClient(
                             "${ChargingProfilesScspServer.CHARGING_PROFILE_CALLBACK_URL}/$requestId",
                     ),
                 ),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseResult()
     }
@@ -89,12 +80,7 @@ class ChargingProfilesScspClient(
                     "response_url" to "$callbackBaseUrl/" +
                         "${ChargingProfilesScspServer.CLEAR_PROFILE_CALLBACK_URL}/$requestId",
                 ),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseResult()
     }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandCpoClient.kt
@@ -1,8 +1,8 @@
 package com.izivia.ocpi.toolkit.modules.commands
 
-import com.izivia.ocpi.toolkit.common.*
+import com.izivia.ocpi.toolkit.common.TransportClientBuilder
+import com.izivia.ocpi.toolkit.common.parseResultOrNull
 import com.izivia.ocpi.toolkit.modules.commands.domain.CommandResult
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeObject
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
@@ -10,7 +10,6 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 
 class CommandCpoClient(
     private val transportClientBuilder: TransportClientBuilder,
-    private val partnerRepository: PartnerRepository,
 ) {
     suspend fun postCommandCallback(
         commandResult: CommandResult,
@@ -18,17 +17,12 @@ class CommandCpoClient(
         responseUrl: String,
     ) =
         transportClientBuilder
-            .build(responseUrl)
+            .buildFor(partnerId, responseUrl)
             .send(
                 HttpRequest(
                     method = HttpMethod.POST,
                     path = "",
                     body = mapper.serializeObject(commandResult),
-                )
-                    .withRequiredHeaders(
-                        requestId = generateUUIDv4Token(),
-                        correlationId = generateUUIDv4Token(),
-                    )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             ).parseResultOrNull<String>()
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/commands/CommandEmspClient.kt
@@ -1,8 +1,9 @@
 package com.izivia.ocpi.toolkit.modules.commands
 
-import com.izivia.ocpi.toolkit.common.*
+import com.izivia.ocpi.toolkit.common.CiString
+import com.izivia.ocpi.toolkit.common.TransportClientBuilder
+import com.izivia.ocpi.toolkit.common.parseResult
 import com.izivia.ocpi.toolkit.modules.commands.domain.*
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.tokens.domain.Token
 import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
@@ -16,7 +17,6 @@ import java.time.Instant
 class CommandEmspClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val partnerId: String,
-    private val partnerRepository: PartnerRepository,
     private val callbackBaseUrl: String,
 ) {
 
@@ -50,12 +50,7 @@ class CommandEmspClient(
                             authorizationReference = authorizationReference,
                         ),
                     ),
-                )
-                    .withRequiredHeaders(
-                        requestId = generateUUIDv4Token(),
-                        correlationId = generateUUIDv4Token(),
-                    )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             )
                 .parseResult()
         }
@@ -75,12 +70,7 @@ class CommandEmspClient(
                             sessionId = sessionId,
                         ),
                     ),
-                )
-                    .withRequiredHeaders(
-                        requestId = generateUUIDv4Token(),
-                        correlationId = generateUUIDv4Token(),
-                    )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             )
                 .parseResult()
         }
@@ -110,12 +100,7 @@ class CommandEmspClient(
                             authorizationReference = authorizationReference,
                         ),
                     ),
-                )
-                    .withRequiredHeaders(
-                        requestId = generateUUIDv4Token(),
-                        correlationId = generateUUIDv4Token(),
-                    )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             )
                 .parseResult()
         }
@@ -135,12 +120,7 @@ class CommandEmspClient(
                             reservationId = reservationId,
                         ),
                     ),
-                )
-                    .withRequiredHeaders(
-                        requestId = generateUUIDv4Token(),
-                        correlationId = generateUUIDv4Token(),
-                    )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             )
                 .parseResult()
         }
@@ -164,12 +144,7 @@ class CommandEmspClient(
                             connectorId = connectorId,
                         ),
                     ),
-                )
-                    .withRequiredHeaders(
-                        requestId = generateUUIDv4Token(),
-                        correlationId = generateUUIDv4Token(),
-                    )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             )
                 .parseResult()
         }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/CredentialsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/CredentialsClient.kt
@@ -1,6 +1,7 @@
 package com.izivia.ocpi.toolkit.modules.credentials
 
-import com.izivia.ocpi.toolkit.common.*
+import com.izivia.ocpi.toolkit.common.parseResult
+import com.izivia.ocpi.toolkit.common.parseResultOrNull
 import com.izivia.ocpi.toolkit.modules.credentials.domain.Credentials
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeObject
@@ -19,12 +20,7 @@ class CredentialsClient(
     override suspend fun get(token: String): Credentials =
         transportClient
             .send(
-                HttpRequest(method = HttpMethod.GET)
-                    .withRequiredHeaders(
-                        requestId = transportClient.generateRequestId(),
-                        correlationId = transportClient.generateCorrelationId(),
-                    )
-                    .authenticate(token = token),
+                HttpRequest(method = HttpMethod.GET),
             )
             .parseResult()
 
@@ -38,12 +34,7 @@ class CredentialsClient(
                 HttpRequest(
                     method = HttpMethod.POST,
                     body = mapper.serializeObject(credentials),
-                )
-                    .withRequiredHeaders(
-                        requestId = transportClient.generateRequestId(),
-                        correlationId = transportClient.generateCorrelationId(),
-                    )
-                    .authenticate(token = token),
+                ),
             )
             .parseResult()
 
@@ -57,24 +48,14 @@ class CredentialsClient(
                 HttpRequest(
                     method = HttpMethod.PUT,
                     body = mapper.serializeObject(credentials),
-                )
-                    .withRequiredHeaders(
-                        requestId = transportClient.generateRequestId(),
-                        correlationId = transportClient.generateCorrelationId(),
-                    )
-                    .authenticate(token = token),
+                ),
             )
             .parseResult()
 
     override suspend fun delete(token: String) {
         transportClient
             .send(
-                HttpRequest(method = HttpMethod.DELETE)
-                    .withRequiredHeaders(
-                        requestId = transportClient.generateRequestId(),
-                        correlationId = transportClient.generateCorrelationId(),
-                    )
-                    .authenticate(token = token),
+                HttpRequest(method = HttpMethod.DELETE),
             )
             .parseResultOrNull<String>()
     }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsClientService.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsClientService.kt
@@ -92,7 +92,7 @@ open class CredentialsClientService(
         )
 
         // Initiate registration process
-        val credentials = buildCredentialClient().post(
+        val credentials = buildCredentialClient(allowTokenA = true).post(
             token = credentialsTokenA,
             credentials = Credentials(
                 token = serverToken,
@@ -225,15 +225,17 @@ open class CredentialsClientService(
         .takeIf { it.isNotEmpty() }
         ?: findLatestMutualVersionAndSaveInformation()
 
-    private suspend fun buildCredentialClient(): CredentialsClient = CredentialsClient(
+    private suspend fun buildCredentialClient(allowTokenA: Boolean = false): CredentialsClient = CredentialsClient(
         transportClient = transportClientBuilder
-            .build(
+            .buildFor(
+                partnerId = partnerId,
                 baseUrl = getOrFindEndpoints()
                     .find { it.identifier == ModuleID.credentials }
                     ?.url
                     ?: throw OcpiServerUnsupportedVersionException(
                         "No credentials endpoint for $partnerId",
                     ),
+                allowTokenA = allowTokenA,
             ),
     )
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/CredentialsServerService.kt
@@ -140,17 +140,14 @@ open class CredentialsServerService(
         debugHeaders: Map<String, String>,
     ) {
         val versions = transportClientBuilder
-            .build(credentials.url)
+            .build(credentials.url, credentials.token)
             .runCatching {
                 // we can not use VersionsClient::getVersions() without some refactoring
                 // regular clients require an established connect and make too many assumptions around headers
                 send(
                     HttpRequest(method = HttpMethod.GET)
-                        .withUpdatedRequiredHeaders(
-                            headers = debugHeaders,
-                            generatedRequestId = generateRequestId(),
-                        )
-                        .authenticate(token = credentials.token),
+                        // we need to forward the correlation id (while request id will get overwritten)
+                        .withHeadersMixin(debugHeaders),
                 )
                     .parseResultList<Version>()
             }
@@ -168,15 +165,12 @@ open class CredentialsServerService(
         partnerRepository.saveVersion(partnerId = partnerId, version = matchingVersion)
 
         val versionDetail = transportClientBuilder
-            .build(matchingVersion.url)
+            .build(matchingVersion.url, credentials.token)
             .runCatching {
                 send(
                     HttpRequest(method = HttpMethod.GET)
-                        .withUpdatedRequiredHeaders(
-                            headers = debugHeaders,
-                            generatedRequestId = generateRequestId(),
-                        )
-                        .authenticate(token = credentials.token),
+                        // we need to forward the correlation id (while request id will get overwritten)
+                        .withHeadersMixin(debugHeaders),
                 )
                     .parseResult<VersionDetails>()
             }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/PartnerProvider.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/credentials/services/PartnerProvider.kt
@@ -1,5 +1,6 @@
 package com.izivia.ocpi.toolkit.modules.credentials.services
 
+import com.izivia.ocpi.toolkit.common.OcpiClientUnknownTokenException
 import com.izivia.ocpi.toolkit.common.OcpiToolkitUnknownEndpointException
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
@@ -20,5 +21,22 @@ class PartnerProvider(
             .find { it.identifier == moduleId && it.role == role }
             ?.url
             ?: throw OcpiToolkitUnknownEndpointException(endpointName = moduleId.name)
+    }
+
+    override suspend fun getClientToken(partnerId: String, allowTokenA: Boolean): String {
+        return with(partnerRepository) {
+            if (allowTokenA) {
+                getCredentialsClientToken(partnerId = partnerId)
+                    ?: getCredentialsTokenA(partnerId = partnerId)
+                    ?: throw OcpiClientUnknownTokenException(
+                        "Could not find token A or client token associated with partner $partnerId",
+                    )
+            } else {
+                getCredentialsClientToken(partnerId = partnerId)
+                    ?: throw OcpiClientUnknownTokenException(
+                        "Could not find client token associated with partner $partnerId",
+                    )
+            }
+        }
     }
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/hubclientinfo/HubClientInfoReceiverClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/hubclientinfo/HubClientInfoReceiverClient.kt
@@ -1,7 +1,8 @@
 package com.izivia.ocpi.toolkit.modules.hubclientinfo
 
-import com.izivia.ocpi.toolkit.common.*
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
+import com.izivia.ocpi.toolkit.common.SearchResult
+import com.izivia.ocpi.toolkit.common.TransportClientBuilder
+import com.izivia.ocpi.toolkit.common.parseSearchResult
 import com.izivia.ocpi.toolkit.modules.hubclientinfo.domain.ClientInfo
 import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
@@ -13,7 +14,6 @@ import java.time.Instant
 class HubClientInfoReceiverClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val partnerId: String,
-    private val partnerRepository: PartnerRepository,
 ) : HubClientInfoSenderInterface {
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
@@ -38,12 +38,7 @@ class HubClientInfoReceiverClient(
                     "offset" to offset.toString(),
                     limit?.let { "limit" to limit.toString() },
                 ).toMap(),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseSearchResult(offset)
     }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/hubclientinfo/HubClientInfoSenderClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/hubclientinfo/HubClientInfoSenderClient.kt
@@ -1,7 +1,8 @@
 package com.izivia.ocpi.toolkit.modules.hubclientinfo
 
-import com.izivia.ocpi.toolkit.common.*
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
+import com.izivia.ocpi.toolkit.common.TransportClientBuilder
+import com.izivia.ocpi.toolkit.common.parseOptionalResult
+import com.izivia.ocpi.toolkit.common.parseResultOrNull
 import com.izivia.ocpi.toolkit.modules.hubclientinfo.domain.ClientInfo
 import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
@@ -14,7 +15,6 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 class HubClientInfoSenderClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val partnerId: String,
-    private val partnerRepository: PartnerRepository,
 ) : HubClientInfoReceiverInterface {
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
@@ -33,12 +33,7 @@ class HubClientInfoSenderClient(
                 HttpRequest(
                     method = HttpMethod.GET,
                     path = "/$countryCode/$partyId",
-                )
-                    .withRequiredHeaders(
-                        requestId = generateRequestId(),
-                        correlationId = generateCorrelationId(),
-                    )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             )
                 .parseOptionalResult()
         }
@@ -54,12 +49,7 @@ class HubClientInfoSenderClient(
                     method = HttpMethod.PUT,
                     path = "/$countryCode/$partyId",
                     body = mapper.serializeObject(clientInfo),
-                )
-                    .withRequiredHeaders(
-                        requestId = generateRequestId(),
-                        correlationId = generateCorrelationId(),
-                    )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             )
                 .parseResultOrNull<Any>()
         }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsCpoClient.kt
@@ -1,7 +1,9 @@
 package com.izivia.ocpi.toolkit.modules.locations
 
-import com.izivia.ocpi.toolkit.common.*
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
+import com.izivia.ocpi.toolkit.common.CiString
+import com.izivia.ocpi.toolkit.common.TransportClientBuilder
+import com.izivia.ocpi.toolkit.common.parseOptionalResult
+import com.izivia.ocpi.toolkit.common.parseResultOrNull
 import com.izivia.ocpi.toolkit.modules.locations.domain.*
 import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
@@ -15,12 +17,10 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
  * Sends calls to an eMSP server
  * @property transportClientBuilder used to build transport client
  * @property partnerId used to know which partner to communicate with
- * @property partnerRepository used to get information about the partner (endpoint, token)
  */
 class LocationsCpoClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val partnerId: String,
-    private val partnerRepository: PartnerRepository,
 ) : LocationsEmspInterface {
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
@@ -39,12 +39,7 @@ class LocationsCpoClient(
             HttpRequest(
                 method = HttpMethod.GET,
                 path = "/$countryCode/$partyId/$locationId",
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseOptionalResult()
     }
@@ -59,12 +54,7 @@ class LocationsCpoClient(
             HttpRequest(
                 method = HttpMethod.GET,
                 path = "/$countryCode/$partyId/$locationId/$evseUid",
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseOptionalResult()
     }
@@ -80,12 +70,7 @@ class LocationsCpoClient(
             HttpRequest(
                 method = HttpMethod.GET,
                 path = "/$countryCode/$partyId/$locationId/$evseUid/$connectorId",
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseOptionalResult()
     }
@@ -101,12 +86,7 @@ class LocationsCpoClient(
                 method = HttpMethod.PUT,
                 path = "/$countryCode/$partyId/$locationId",
                 body = mapper.serializeObject(location),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseResultOrNull() ?: LocationPartial()
     }
@@ -123,12 +103,7 @@ class LocationsCpoClient(
                 method = HttpMethod.PUT,
                 path = "/$countryCode/$partyId/$locationId/$evseUid",
                 body = mapper.serializeObject(evse),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseResultOrNull() ?: EvsePartial()
     }
@@ -146,12 +121,7 @@ class LocationsCpoClient(
                 method = HttpMethod.PUT,
                 path = "/$countryCode/$partyId/$locationId/$evseUid/$connectorId",
                 body = mapper.serializeObject(connector),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseResultOrNull() ?: ConnectorPartial()
     }
@@ -167,12 +137,7 @@ class LocationsCpoClient(
                 method = HttpMethod.PATCH,
                 path = "/$countryCode/$partyId/$locationId",
                 body = mapper.serializeObject(location),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseResultOrNull()
     }
@@ -189,12 +154,7 @@ class LocationsCpoClient(
                 method = HttpMethod.PATCH,
                 path = "/$countryCode/$partyId/$locationId/$evseUid",
                 body = mapper.serializeObject(evse),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseResultOrNull()
     }
@@ -212,12 +172,7 @@ class LocationsCpoClient(
                 method = HttpMethod.PATCH,
                 path = "/$countryCode/$partyId/$locationId/$evseUid/$connectorId",
                 body = mapper.serializeObject(connector),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseResultOrNull()
     }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/locations/LocationsEmspClient.kt
@@ -1,7 +1,6 @@
 package com.izivia.ocpi.toolkit.modules.locations
 
 import com.izivia.ocpi.toolkit.common.*
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.locations.domain.Connector
 import com.izivia.ocpi.toolkit.modules.locations.domain.Evse
 import com.izivia.ocpi.toolkit.modules.locations.domain.Location
@@ -17,12 +16,10 @@ import java.time.Instant
  * Sends calls to the CPO
  * @property transportClientBuilder used to build transport client
  * @property partnerId used to know which partner to communicate with
- * @property partnerRepository used to get information about the partner (endpoint, token)
  */
 class LocationsEmspClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val partnerId: String,
-    private val partnerRepository: PartnerRepository,
     private val ignoreInvalidListEntry: Boolean = false,
 ) : LocationsCpoInterface {
 
@@ -48,12 +45,7 @@ class LocationsEmspClient(
                     "offset" to offset.toString(),
                     limit?.let { "limit" to limit.toString() },
                 ).toMap(),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         ).let { res ->
             if (ignoreInvalidListEntry) {
                 res.parseSearchResultIgnoringInvalid<Location, LocationPartial>(offset)
@@ -68,7 +60,6 @@ class LocationsEmspClient(
     ): SearchResult<Location>? = getNextPage<Location, LocationPartial>(
         transportClientBuilder = transportClientBuilder,
         partnerId = partnerId,
-        partnerRepository = partnerRepository,
         previousResponse = previousResponse,
         ignoreInvalidListEntry = ignoreInvalidListEntry,
     )
@@ -78,12 +69,7 @@ class LocationsEmspClient(
             HttpRequest(
                 method = HttpMethod.GET,
                 path = "/$locationId",
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseOptionalResult()
     }
@@ -94,12 +80,7 @@ class LocationsEmspClient(
                 HttpRequest(
                     method = HttpMethod.GET,
                     path = "/$locationId/$evseUid",
-                )
-                    .withRequiredHeaders(
-                        requestId = generateRequestId(),
-                        correlationId = generateCorrelationId(),
-                    )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             )
                 .parseOptionalResult()
         }
@@ -113,12 +94,7 @@ class LocationsEmspClient(
             HttpRequest(
                 method = HttpMethod.GET,
                 path = "/$locationId/$evseUid/$connectorId",
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseOptionalResult()
     }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsCpoClient.kt
@@ -1,7 +1,9 @@
 package com.izivia.ocpi.toolkit.modules.sessions
 
-import com.izivia.ocpi.toolkit.common.*
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
+import com.izivia.ocpi.toolkit.common.CiString
+import com.izivia.ocpi.toolkit.common.TransportClientBuilder
+import com.izivia.ocpi.toolkit.common.parseOptionalResult
+import com.izivia.ocpi.toolkit.common.parseResultOrNull
 import com.izivia.ocpi.toolkit.modules.sessions.domain.Session
 import com.izivia.ocpi.toolkit.modules.sessions.domain.SessionPartial
 import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
@@ -16,12 +18,10 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
  * Sends calls to an eMSP server
  * @property transportClientBuilder used to build transport client
  * @property partnerId used to know which partner to communicate with
- * @property partnerRepository used to get information about the partner (endpoint, token)
  */
 class SessionsCpoClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val partnerId: String,
-    private val partnerRepository: PartnerRepository,
 ) : SessionsEmspInterface {
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
         .buildFor(
@@ -40,11 +40,7 @@ class SessionsCpoClient(
                 HttpRequest(
                     method = HttpMethod.GET,
                     path = "/$countryCode/$partyId/$sessionId",
-                ).withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             )
                 .parseOptionalResult()
         }
@@ -61,11 +57,7 @@ class SessionsCpoClient(
                     method = HttpMethod.PUT,
                     path = "/$countryCode/$partyId/$sessionId",
                     body = mapper.serializeObject(session),
-                ).withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             )
                 .parseResultOrNull() ?: SessionPartial()
         }
@@ -82,11 +74,7 @@ class SessionsCpoClient(
                     method = HttpMethod.PATCH,
                     path = "/$countryCode/$partyId/$sessionId",
                     body = mapper.serializeObject(session),
-                ).withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             )
                 .parseResultOrNull()
         }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/sessions/SessionsEmspClient.kt
@@ -1,7 +1,6 @@
 package com.izivia.ocpi.toolkit.modules.sessions
 
 import com.izivia.ocpi.toolkit.common.*
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.sessions.domain.ChargingPreferences
 import com.izivia.ocpi.toolkit.modules.sessions.domain.ChargingPreferencesResponseType
 import com.izivia.ocpi.toolkit.modules.sessions.domain.Session
@@ -19,12 +18,10 @@ import java.time.Instant
  * Sends calls to the CPO
  * @property transportClientBuilder used to build transport client
  * @property partnerId used to know which partner to communicate with
- * @property partnerRepository used to get information about the partner (endpoint, token)
  */
 class SessionsEmspClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val partnerId: String,
-    private val partnerRepository: PartnerRepository,
     private val ignoreInvalidListEntry: Boolean = false,
 ) : SessionsCpoInterface {
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
@@ -50,11 +47,7 @@ class SessionsEmspClient(
                         "offset" to offset.toString(),
                         limit?.let { "limit" to limit.toString() },
                     ).toMap(),
-                ).withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             ).let { res ->
                 if (ignoreInvalidListEntry) {
                     res.parseSearchResultIgnoringInvalid<Session, SessionPartial>(offset)
@@ -69,7 +62,6 @@ class SessionsEmspClient(
     ): SearchResult<Session>? = getNextPage<Session, SessionPartial>(
         transportClientBuilder = transportClientBuilder,
         partnerId = partnerId,
-        partnerRepository = partnerRepository,
         previousResponse = previousResponse,
         ignoreInvalidListEntry = ignoreInvalidListEntry,
     )
@@ -84,11 +76,7 @@ class SessionsEmspClient(
                     method = HttpMethod.PUT,
                     path = "/$sessionId/charging_preferences",
                     body = mapper.serializeObject(chargingPreferences),
-                ).withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             )
                 .parseResult()
         }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tariff/TariffCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tariff/TariffCpoClient.kt
@@ -1,7 +1,9 @@
 package com.izivia.ocpi.toolkit.modules.tariff
 
-import com.izivia.ocpi.toolkit.common.*
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
+import com.izivia.ocpi.toolkit.common.CiString
+import com.izivia.ocpi.toolkit.common.TransportClientBuilder
+import com.izivia.ocpi.toolkit.common.parseOptionalResult
+import com.izivia.ocpi.toolkit.common.parseResultOrNull
 import com.izivia.ocpi.toolkit.modules.tariff.domain.Tariff
 import com.izivia.ocpi.toolkit.modules.tariff.domain.TariffPartial
 import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
@@ -15,7 +17,6 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 class TariffCpoClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val partnerId: String,
-    private val partnerRepository: PartnerRepository,
 ) : TariffEmspInterface {
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
@@ -34,12 +35,7 @@ class TariffCpoClient(
             HttpRequest(
                 method = HttpMethod.GET,
                 path = "/$countryCode/$partyId/$tariffId",
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseOptionalResult()
     }
@@ -55,12 +51,7 @@ class TariffCpoClient(
                 method = HttpMethod.PUT,
                 path = "/$countryCode/$partyId/$tariffId",
                 body = mapper.serializeObject(tariff),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseResultOrNull() ?: TariffPartial()
     }
@@ -74,12 +65,7 @@ class TariffCpoClient(
             HttpRequest(
                 method = HttpMethod.DELETE,
                 path = "/$countryCode/$partyId/$tariffId",
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         )
             .parseResultOrNull<Any>()
     }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tariff/TariffEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tariff/TariffEmspClient.kt
@@ -1,7 +1,6 @@
 package com.izivia.ocpi.toolkit.modules.tariff
 
 import com.izivia.ocpi.toolkit.common.*
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.tariff.domain.Tariff
 import com.izivia.ocpi.toolkit.modules.tariff.domain.TariffPartial
 import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
@@ -14,7 +13,6 @@ import java.time.Instant
 class TariffEmspClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val partnerId: String,
-    private val partnerRepository: PartnerRepository,
     private val ignoreInvalidListEntry: Boolean = false,
 ) : TariffCpoInterface {
 
@@ -40,12 +38,7 @@ class TariffEmspClient(
                     "offset" to offset.toString(),
                     limit?.let { "limit" to limit.toString() },
                 ).toMap(),
-            )
-                .withRequiredHeaders(
-                    requestId = generateRequestId(),
-                    correlationId = generateCorrelationId(),
-                )
-                .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+            ),
         ).let { res ->
             if (ignoreInvalidListEntry) {
                 res.parseSearchResultIgnoringInvalid<Tariff, TariffPartial>(offset)
@@ -60,7 +53,6 @@ class TariffEmspClient(
     ): SearchResult<Tariff>? = getNextPage<Tariff, TariffPartial>(
         transportClientBuilder = transportClientBuilder,
         partnerId = partnerId,
-        partnerRepository = partnerRepository,
         previousResponse = previousResponse,
         ignoreInvalidListEntry = ignoreInvalidListEntry,
     )

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensCpoClient.kt
@@ -1,7 +1,6 @@
 package com.izivia.ocpi.toolkit.modules.tokens
 
 import com.izivia.ocpi.toolkit.common.*
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.tokens.domain.*
 import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
@@ -16,12 +15,10 @@ import java.time.Instant
  * Sends calls to an eMSP server
  * @property transportClientBuilder used to build transport client
  * @property partnerId used to know which partner to communicate with
- * @property partnerRepository used to get information about the partner (endpoint, token)
  */
 class TokensCpoClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val partnerId: String,
-    private val partnerRepository: PartnerRepository,
     private val ignoreInvalidListEntry: Boolean = false,
 ) : TokensEmspInterface {
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
@@ -47,12 +44,7 @@ class TokensCpoClient(
                         "offset" to offset.toString(),
                         limit?.let { "limit" to limit.toString() },
                     ).toMap(),
-                )
-                    .withRequiredHeaders(
-                        requestId = generateRequestId(),
-                        correlationId = generateCorrelationId(),
-                    )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             ).let { res ->
                 if (ignoreInvalidListEntry) {
                     res.parseSearchResultIgnoringInvalid<Token, TokenPartial>(offset)
@@ -67,7 +59,6 @@ class TokensCpoClient(
     ): SearchResult<Token>? = getNextPage<Token, TokenPartial>(
         transportClientBuilder = transportClientBuilder,
         partnerId = partnerId,
-        partnerRepository = partnerRepository,
         previousResponse = previousResponse,
         ignoreInvalidListEntry = ignoreInvalidListEntry,
     )
@@ -84,12 +75,7 @@ class TokensCpoClient(
                     path = "/$tokenUid/authorize",
                     queryParams = listOfNotNull(type?.let { "type" to type.toString() }).toMap(),
                     body = locationReferences.run(mapper::serializeObject),
-                )
-                    .withRequiredHeaders(
-                        requestId = generateRequestId(),
-                        correlationId = generateCorrelationId(),
-                    )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             ).parseResult()
         }
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/tokens/TokensEmspClient.kt
@@ -1,7 +1,9 @@
 package com.izivia.ocpi.toolkit.modules.tokens
 
-import com.izivia.ocpi.toolkit.common.*
-import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
+import com.izivia.ocpi.toolkit.common.CiString
+import com.izivia.ocpi.toolkit.common.TransportClientBuilder
+import com.izivia.ocpi.toolkit.common.parseOptionalResult
+import com.izivia.ocpi.toolkit.common.parseResultOrNull
 import com.izivia.ocpi.toolkit.modules.tokens.domain.Token
 import com.izivia.ocpi.toolkit.modules.tokens.domain.TokenPartial
 import com.izivia.ocpi.toolkit.modules.tokens.domain.TokenType
@@ -17,12 +19,10 @@ import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
  * Sends calls to the CPO
  * @property transportClientBuilder used to build transport client
  * @property partnerId used to know which partner to communicate with
- * @property partnerRepository used to get information about the partner (endpoint, token)
  */
 class TokensEmspClient(
     private val transportClientBuilder: TransportClientBuilder,
     private val partnerId: String,
-    private val partnerRepository: PartnerRepository,
 ) : TokensCpoInterface {
 
     private suspend fun buildTransport(): TransportClient = transportClientBuilder
@@ -44,12 +44,7 @@ class TokensEmspClient(
                     method = HttpMethod.GET,
                     path = "/$countryCode/$partyId/$tokenUid",
                     queryParams = listOfNotNull(type?.let { "type" to type.toString() }).toMap(),
-                )
-                    .withRequiredHeaders(
-                        requestId = generateRequestId(),
-                        correlationId = generateCorrelationId(),
-                    )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             ).parseOptionalResult()
         }
 
@@ -69,12 +64,7 @@ class TokensEmspClient(
                     queryParams = listOfNotNull(
                         type?.let { "type" to type.toString() },
                     ).toMap(),
-                )
-                    .withRequiredHeaders(
-                        requestId = generateRequestId(),
-                        correlationId = generateCorrelationId(),
-                    )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             ).parseResultOrNull() ?: TokenPartial()
         }
 
@@ -94,12 +84,7 @@ class TokensEmspClient(
                     queryParams = listOfNotNull(
                         type?.let { "type" to type.toString() },
                     ).toMap(),
-                )
-                    .withRequiredHeaders(
-                        requestId = generateRequestId(),
-                        correlationId = generateCorrelationId(),
-                    )
-                    .authenticate(partnerRepository = partnerRepository, partnerId = partnerId),
+                ),
             ).parseResultOrNull()
         }
 }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionDetailsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionDetailsClient.kt
@@ -1,6 +1,8 @@
 package com.izivia.ocpi.toolkit.modules.versions
 
-import com.izivia.ocpi.toolkit.common.*
+import com.izivia.ocpi.toolkit.common.OcpiToolkitUnknownEndpointException
+import com.izivia.ocpi.toolkit.common.TransportClientBuilder
+import com.izivia.ocpi.toolkit.common.parseResult
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.versions.domain.VersionDetails
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
@@ -21,24 +23,17 @@ class VersionDetailsClient(
     override suspend fun getVersionDetails(): VersionDetails =
         with(
             transportClientBuilder
-                .build(
+                .buildFor(
+                    partnerId = partnerId,
                     baseUrl = partnerRepository
                         .getVersion(partnerId = partnerId)
                         ?.url
                         ?: throw OcpiToolkitUnknownEndpointException("version details"),
+                    allowTokenA = true,
                 ),
         ) {
             send(
-                HttpRequest(method = HttpMethod.GET)
-                    .withRequiredHeaders(
-                        requestId = generateRequestId(),
-                        correlationId = generateCorrelationId(),
-                    )
-                    .authenticate(
-                        partnerRepository = partnerRepository,
-                        partnerId = partnerId,
-                        allowTokenA = true,
-                    ),
+                HttpRequest(method = HttpMethod.GET),
             )
                 .parseResult()
         }

--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsClient.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/modules/versions/VersionsClient.kt
@@ -1,6 +1,8 @@
 package com.izivia.ocpi.toolkit.modules.versions
 
-import com.izivia.ocpi.toolkit.common.*
+import com.izivia.ocpi.toolkit.common.OcpiToolkitUnknownEndpointException
+import com.izivia.ocpi.toolkit.common.TransportClientBuilder
+import com.izivia.ocpi.toolkit.common.parseResultList
 import com.izivia.ocpi.toolkit.modules.credentials.repositories.PartnerRepository
 import com.izivia.ocpi.toolkit.modules.versions.domain.Version
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
@@ -21,23 +23,16 @@ class VersionsClient(
     override suspend fun getVersions(): List<Version> =
         with(
             transportClientBuilder
-                .build(
+                .buildFor(
+                    partnerId = partnerId,
                     baseUrl = partnerRepository
                         .getPartnerUrl(partnerId = partnerId)
                         ?: throw OcpiToolkitUnknownEndpointException("version with no url"),
+                    allowTokenA = true,
                 ),
         ) {
             send(
-                HttpRequest(method = HttpMethod.GET)
-                    .withRequiredHeaders(
-                        requestId = generateRequestId(),
-                        correlationId = generateCorrelationId(),
-                    )
-                    .authenticate(
-                        partnerRepository = partnerRepository,
-                        partnerId = partnerId,
-                        allowTokenA = true,
-                    ),
+                HttpRequest(method = HttpMethod.GET),
             )
                 .parseResultList<Version>()
         }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/common/TestTransportClient.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/common/TestTransportClient.kt
@@ -1,0 +1,12 @@
+package com.izivia.ocpi.toolkit.common
+
+import com.izivia.ocpi.toolkit.transport.TransportClient
+import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
+import com.izivia.ocpi.toolkit.transport.domain.HttpResponse
+import kotlinx.coroutines.runBlocking
+
+class TestTransportClient(private var client: TransportClient) {
+    fun send(request: HttpRequest): HttpResponse = runBlocking {
+        client.send(request)
+    }
+}

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/cpo/mockLocationsCpoRepoBuilder.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/cpo/mockLocationsCpoRepoBuilder.kt
@@ -1,12 +1,12 @@
 package com.izivia.ocpi.toolkit.modules.locations.http.cpo
 
+import com.izivia.ocpi.toolkit.common.TestTransportClient
 import com.izivia.ocpi.toolkit.common.TimeProvider
 import com.izivia.ocpi.toolkit.modules.locations.LocationsCpoInterface
 import com.izivia.ocpi.toolkit.modules.locations.LocationsCpoServer
 import com.izivia.ocpi.toolkit.modules.locations.services.LocationsCpoValidator
 import com.izivia.ocpi.toolkit.modules.versions.repositories.InMemoryVersionsRepository
 import com.izivia.ocpi.toolkit.samples.common.Http4kTransportServer
-import com.izivia.ocpi.toolkit.transport.TransportClient
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
@@ -15,7 +15,7 @@ import java.time.Instant
 internal const val nowString = "2015-06-30T21:59:59Z"
 private val now = Instant.parse(nowString)
 
-internal fun LocationsCpoInterface.buildServer(): TransportClient {
+internal fun LocationsCpoInterface.buildServer(): TestTransportClient {
     val timeProvider = mockk<TimeProvider>()
     every { timeProvider.now() } returns now
 
@@ -31,5 +31,5 @@ internal fun LocationsCpoInterface.buildServer(): TransportClient {
         ).registerOn(transportServer)
     }
 
-    return transportServer.initRouterAndBuildClient()
+    return TestTransportClient(transportServer.initRouterAndBuildClient())
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspClientGetLocationsTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspClientGetLocationsTest.kt
@@ -50,7 +50,6 @@ class LocationsEmspClientGetLocationsTest : TestWithSerializerProviders {
                 listOf(invalidLocation, validLocation.toPartial(), invalidLocation),
             ),
             partnerId = "irrelevant",
-            partnerRepository = mockPartnerRepository,
             ignoreInvalidListEntry = true,
         )
 
@@ -70,7 +69,6 @@ class LocationsEmspClientGetLocationsTest : TestWithSerializerProviders {
                 listOf(validLocation.toPartial(), invalidLocation),
             ),
             partnerId = "irrelevant",
-            partnerRepository = mockPartnerRepository,
         )
 
         runBlocking {
@@ -87,7 +85,6 @@ class LocationsEmspClientGetLocationsTest : TestWithSerializerProviders {
         val client = LocationsEmspClient(
             transportClientBuilder = mockSearchResult(listOf(validLocation, validLocation)),
             partnerId = "irrelevant",
-            partnerRepository = mockPartnerRepository,
         )
 
         runBlocking {
@@ -120,14 +117,28 @@ private inline fun <reified T> mockSearchResult(data: List<T>) =
 class MockHttpTransportClientBuilder(
     private val handler: HttpHandler,
 ) : TransportClientBuilder {
+
     override suspend fun buildFor(
         partnerId: String,
         module: ModuleID,
         role: InterfaceRole,
+        allowTokenA: Boolean,
     ): TransportClient {
-        return build("")
+        return Http4kTransportClient(handler)
     }
 
-    override fun build(baseUrl: String): TransportClient =
-        Http4kTransportClient(handler)
+    override suspend fun buildFor(
+        partnerId: String,
+        baseUrl: String,
+        allowTokenA: Boolean,
+    ): TransportClient {
+        return Http4kTransportClient(handler)
+    }
+
+    override suspend fun build(
+        baseUrl: String,
+        authToken: String,
+    ): TransportClient {
+        return Http4kTransportClient(handler)
+    }
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/mockLocationsEmspRepoBuilder.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/mockLocationsEmspRepoBuilder.kt
@@ -1,5 +1,6 @@
 package com.izivia.ocpi.toolkit.modules.locations.http.emsp
 
+import com.izivia.ocpi.toolkit.common.TestTransportClient
 import com.izivia.ocpi.toolkit.common.TimeProvider
 import com.izivia.ocpi.toolkit.modules.locations.LocationsEmspServer
 import com.izivia.ocpi.toolkit.modules.locations.repositories.LocationsEmspRepository
@@ -7,7 +8,6 @@ import com.izivia.ocpi.toolkit.modules.locations.services.LocationsEmspService
 import com.izivia.ocpi.toolkit.modules.locations.services.LocationsEmspValidator
 import com.izivia.ocpi.toolkit.modules.versions.repositories.InMemoryVersionsRepository
 import com.izivia.ocpi.toolkit.samples.common.Http4kTransportServer
-import com.izivia.ocpi.toolkit.transport.TransportClient
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
@@ -16,7 +16,7 @@ import java.time.Instant
 internal const val nowString = "2015-06-30T21:59:59Z"
 private val now = Instant.parse(nowString)
 
-internal fun LocationsEmspRepository.buildServer(): TransportClient {
+internal fun LocationsEmspRepository.buildServer(): TestTransportClient {
     val timeProvider = mockk<TimeProvider>()
     every { timeProvider.now() } returns now
 
@@ -32,5 +32,5 @@ internal fun LocationsEmspRepository.buildServer(): TransportClient {
         ).registerOn(transportServer)
     }
 
-    return transportServer.initRouterAndBuildClient()
+    return TestTransportClient(transportServer.initRouterAndBuildClient())
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/tokens/http/cpo/mockTokensCpoRepoBuilder.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/tokens/http/cpo/mockTokensCpoRepoBuilder.kt
@@ -1,12 +1,12 @@
 package com.izivia.ocpi.toolkit.modules.tokens.http.cpo
 
+import com.izivia.ocpi.toolkit.common.TestTransportClient
 import com.izivia.ocpi.toolkit.common.TimeProvider
 import com.izivia.ocpi.toolkit.modules.tokens.TokensCpoServer
 import com.izivia.ocpi.toolkit.modules.tokens.repositories.TokensCpoRepository
 import com.izivia.ocpi.toolkit.modules.tokens.services.TokensCpoService
 import com.izivia.ocpi.toolkit.modules.versions.repositories.InMemoryVersionsRepository
 import com.izivia.ocpi.toolkit.samples.common.Http4kTransportServer
-import com.izivia.ocpi.toolkit.transport.TransportClient
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
@@ -15,7 +15,7 @@ import java.time.Instant
 internal const val nowString = "2015-06-30T21:59:59Z"
 private val now = Instant.parse(nowString)
 
-internal fun TokensCpoRepository.buildServer(): TransportClient {
+internal fun TokensCpoRepository.buildServer(): TestTransportClient {
     val timeProvider = mockk<TimeProvider>()
     every { timeProvider.now() } returns now
 
@@ -31,5 +31,5 @@ internal fun TokensCpoRepository.buildServer(): TransportClient {
         ).registerOn(transportServer)
     }
 
-    return transportServer.initRouterAndBuildClient()
+    return TestTransportClient(transportServer.initRouterAndBuildClient())
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/tokens/http/emsp/mockTokensEmspRepoBuilder.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/tokens/http/emsp/mockTokensEmspRepoBuilder.kt
@@ -1,12 +1,12 @@
 package com.izivia.ocpi.toolkit.modules.tokens.http.emsp
 
+import com.izivia.ocpi.toolkit.common.TestTransportClient
 import com.izivia.ocpi.toolkit.common.TimeProvider
 import com.izivia.ocpi.toolkit.modules.tokens.TokensEmspServer
 import com.izivia.ocpi.toolkit.modules.tokens.repositories.TokensEmspRepository
 import com.izivia.ocpi.toolkit.modules.tokens.services.TokensEmspValidator
 import com.izivia.ocpi.toolkit.modules.versions.repositories.InMemoryVersionsRepository
 import com.izivia.ocpi.toolkit.samples.common.Http4kTransportServer
-import com.izivia.ocpi.toolkit.transport.TransportClient
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
@@ -15,7 +15,7 @@ import java.time.Instant
 internal const val nowString = "2015-06-30T21:59:59Z"
 private val now = Instant.parse(nowString)
 
-internal fun TokensEmspRepository.buildServer(): TransportClient {
+internal fun TokensEmspRepository.buildServer(): TestTransportClient {
     val timeProvider = mockk<TimeProvider>()
     every { timeProvider.now() } returns now
 
@@ -31,5 +31,5 @@ internal fun TokensEmspRepository.buildServer(): TransportClient {
         ).registerOn(transportServer)
     }
 
-    return transportServer.initRouterAndBuildClient()
+    return TestTransportClient(transportServer.initRouterAndBuildClient())
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Http4kTransportClient.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Http4kTransportClient.kt
@@ -1,6 +1,7 @@
 package com.izivia.ocpi.toolkit.samples.common
 
-import com.izivia.ocpi.toolkit.transport.TransportClient
+import com.izivia.ocpi.toolkit.transport.AbstractTransportClient
+import com.izivia.ocpi.toolkit.transport.domain.HttpHeaders
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 import com.izivia.ocpi.toolkit.transport.domain.HttpResponse
 import com.izivia.ocpi.toolkit.transport.domain.parseHttpStatus
@@ -13,9 +14,10 @@ var requestCounter = 1
 var correlationCounter = 1
 
 class Http4kTransportClient(
+    authToken: String,
     val client: HttpHandler,
-) : TransportClient {
-    override fun send(request: HttpRequest): HttpResponse {
+) : AbstractTransportClient(authToken) {
+    override suspend fun doSend(request: HttpRequest): HttpResponse {
         return client(request.toHttp4k()).let {
             HttpResponse(
                 status = parseHttpStatus(it.status.code),
@@ -27,15 +29,21 @@ class Http4kTransportClient(
         }
     }
 
-    override suspend fun generateCorrelationId(): String = "corr-id-$correlationCounter"
-        .also { correlationCounter += 1 }
+    override suspend fun generateCorrelationId(request: HttpRequest): String =
+        request.getHeader(HttpHeaders.X_CORRELATION_ID) ?: "corr-id-${correlationCounter++}"
 
-    override suspend fun generateRequestId(): String = "req-id-$requestCounter"
-        .also { requestCounter += 1 }
+    override suspend fun generateRequestId(): String = "req-id-${requestCounter++}"
 
     companion object {
+        operator fun invoke(client: HttpHandler) =
+            Http4kTransportClient(
+                authToken = "*",
+                client = client,
+            )
+
         operator fun invoke(baseUrl: String) =
             Http4kTransportClient(
+                authToken = "*",
                 ClientFilters.SetBaseUriFrom(Uri.of(baseUrl)).then(OkHttp()),
             )
     }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Http4kTransportClientBuilder.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Http4kTransportClientBuilder.kt
@@ -6,9 +6,21 @@ import com.izivia.ocpi.toolkit.modules.versions.domain.InterfaceRole
 import com.izivia.ocpi.toolkit.modules.versions.domain.ModuleID
 import com.izivia.ocpi.toolkit.transport.AbstractTransportClientBuilder
 import com.izivia.ocpi.toolkit.transport.TransportClient
+import org.http4k.client.OkHttp
+import org.http4k.core.Uri
+import org.http4k.core.then
+import org.http4k.filter.ClientFilters
 
 class Http4kTransportClientBuilder(
     partnerProvider: PartnerProvider,
 ) : TransportClientBuilder, AbstractTransportClientBuilder<ModuleID, InterfaceRole>(partnerProvider) {
-    override fun build(baseUrl: String): TransportClient = Http4kTransportClient(baseUrl)
+    override suspend fun build(
+        baseUrl: String,
+        authToken: String,
+    ): TransportClient {
+        return Http4kTransportClient(
+            client = ClientFilters.SetBaseUriFrom(Uri.of(baseUrl)).then(OkHttp()),
+            authToken = authToken,
+        )
+    }
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Http4kTransportServer.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Http4kTransportServer.kt
@@ -1,9 +1,9 @@
 package com.izivia.ocpi.toolkit.samples.common
 
 import com.izivia.ocpi.toolkit.common.*
-import com.izivia.ocpi.toolkit.common.context.ResponseMessageRoutingHeaders
 import com.izivia.ocpi.toolkit.common.validation.toReadableString
 import com.izivia.ocpi.toolkit.transport.TransportServer
+import com.izivia.ocpi.toolkit.transport.context.ResponseMessageRoutingHeaders
 import com.izivia.ocpi.toolkit.transport.domain.*
 import kotlinx.coroutines.runBlocking
 import org.http4k.core.*

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsCpoClient.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsCpoClient.kt
@@ -13,7 +13,6 @@ fun main() {
     val locationsCpoClient = LocationsCpoClient(
         transportClientBuilder = Http4kTransportClientBuilder(PartnerProvider(DUMMY_PLATFORM_REPOSITORY)),
         partnerId = emspServerVersionsUrl,
-        partnerRepository = DUMMY_PLATFORM_REPOSITORY,
     )
 
     // We can use it

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsEmspClient.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/locations/LocationsEmspClient.kt
@@ -13,7 +13,6 @@ fun main() {
     val locationsEmspClient = LocationsEmspClient(
         transportClientBuilder = Http4kTransportClientBuilder(PartnerProvider(DUMMY_PLATFORM_REPOSITORY)),
         partnerId = cpoServerVersionsUrl,
-        partnerRepository = DUMMY_PLATFORM_REPOSITORY,
     )
 
     // We can use it

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/CredentialsIntegrationTests.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/CredentialsIntegrationTests.kt
@@ -26,6 +26,7 @@ import com.izivia.ocpi.toolkit.tests.integration.mock.PartnerMongoRepository
 import com.izivia.ocpi.toolkit.transport.domain.HttpException
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.izivia.ocpi.toolkit.transport.domain.HttpStatus
+import com.izivia.ocpi.toolkit.transport.encodeBase64
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoDatabase
 import kotlinx.coroutines.runBlocking
@@ -237,7 +238,7 @@ class CredentialsIntegrationTests : BaseServerIntegrationTest(), TestWithSeriali
         // We don't need to register, we will use TOKEN_A for our requests
 
         val versionsClient = VersionsClient(
-            transportClientBuilder = Http4kTransportClientBuilder(receiverServer.partnerProvider),
+            transportClientBuilder = Http4kTransportClientBuilder(senderServer.partnerProvider),
             partnerId = receiverServer.versionsEndpoint,
             partnerRepository = senderServer.partnerRepository,
         )

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/LocationsIntegrationTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/tests/integration/LocationsIntegrationTest.kt
@@ -2,7 +2,6 @@ package com.izivia.ocpi.toolkit.tests.integration
 
 import com.izivia.ocpi.toolkit.common.Header
 import com.izivia.ocpi.toolkit.common.TestWithSerializerProviders
-import com.izivia.ocpi.toolkit.common.context.RequestMessageRoutingHeaders
 import com.izivia.ocpi.toolkit.modules.credentials.services.PartnerProvider
 import com.izivia.ocpi.toolkit.modules.locations.LocationsCpoServer
 import com.izivia.ocpi.toolkit.modules.locations.LocationsEmspClient
@@ -15,6 +14,7 @@ import com.izivia.ocpi.toolkit.serialization.OcpiSerializer
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.tests.integration.common.BaseServerIntegrationTest
 import com.izivia.ocpi.toolkit.tests.integration.mock.LocationsCpoMongoRepository
+import com.izivia.ocpi.toolkit.transport.context.RequestMessageRoutingHeaders
 import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
 import com.mongodb.client.MongoDatabase
 import kotlinx.coroutines.runBlocking
@@ -82,7 +82,6 @@ class LocationsIntegrationTest : BaseServerIntegrationTest(), TestWithSerializer
         val locationsEmspClient = LocationsEmspClient(
             transportClientBuilder = Http4kTransportClientBuilder(PartnerProvider(partnerRepo)),
             partnerId = cpoServerVersionsUrl,
-            partnerRepository = partnerRepo,
         )
 
         // Tests

--- a/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/Base64.kt
+++ b/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/Base64.kt
@@ -1,0 +1,13 @@
+package com.izivia.ocpi.toolkit.transport
+
+import java.util.*
+
+/**
+ * Encode a string in base64, also @see String#decodeBase64()
+ */
+fun String.encodeBase64(): String = Base64.getEncoder().encodeToString(this.encodeToByteArray())
+
+/**
+ * Decodes a base64-encoded string, also @see String#encodeBase64()
+ */
+fun String.decodeBase64(): String = Base64.getDecoder().decode(this).decodeToString()

--- a/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/PartnerProviderInterface.kt
+++ b/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/PartnerProviderInterface.kt
@@ -2,4 +2,5 @@ package com.izivia.ocpi.toolkit.transport
 
 interface PartnerProviderInterface<M, R> {
     suspend fun getEndpointUrl(partnerId: String, moduleId: M, role: R): String
+    suspend fun getClientToken(partnerId: String, allowTokenA: Boolean): String
 }

--- a/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/TransportClient.kt
+++ b/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/TransportClient.kt
@@ -1,5 +1,8 @@
 package com.izivia.ocpi.toolkit.transport
 
+import com.izivia.ocpi.toolkit.transport.context.currentRequestMessageRoutingHeadersOrNull
+import com.izivia.ocpi.toolkit.transport.domain.HttpContentType
+import com.izivia.ocpi.toolkit.transport.domain.HttpHeaders
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
 import com.izivia.ocpi.toolkit.transport.domain.HttpResponse
 import java.util.*
@@ -10,17 +13,50 @@ interface TransportClient {
      * @param request the request to be sent to a server through the transport layer
      * @return the response sent by the server
      */
-    fun send(request: HttpRequest): HttpResponse
+    suspend fun send(request: HttpRequest): HttpResponse
+}
 
-    /**
-     * Override this method if you want to use your own login to generate de X_Correlation_ID header value.
-     * @return String X_Correlation_ID header value
-     */
-    suspend fun generateCorrelationId(): String = UUID.randomUUID().toString()
+abstract class AbstractTransportClient(
+    private val authToken: String,
+) : TransportClient {
+    override suspend fun send(request: HttpRequest): HttpResponse {
+        val enhancedRequest = request.withRequiredHeaders(
+            authToken = generateAuthToken(),
+            requestId = generateRequestId(),
+            correlationId = generateCorrelationId(request),
+            contentTypeHeader = generateContentType(request),
+        )
+            .withHeadersMixin(generateRequestMessageRoutingHeaders()?.toHttpHeaders() ?: emptyMap())
+
+        return doSend(enhancedRequest)
+    }
+
+    protected open suspend fun generateAuthToken(): String {
+        return "Token ${authToken.encodeBase64()}"
+    }
 
     /**
      * Override this method if you want to use your own login to generate de X_Request_ID header value
      * @return String X_Request_ID header value
      */
-    suspend fun generateRequestId(): String = UUID.randomUUID().toString()
+    protected open suspend fun generateRequestId(): String = UUID.randomUUID().toString()
+
+    /**
+     * Override this method if you want to use your own login to generate de X_Correlation_ID header value.
+     * By default, preserves previously set correlation id
+     * @return String X_Correlation_ID header value
+     */
+    protected open suspend fun generateCorrelationId(request: HttpRequest): String =
+        request.getHeader(HttpHeaders.X_CORRELATION_ID) ?: UUID.randomUUID().toString()
+
+    /**
+     * Overriding this method should only be needed, if you need support a custom module
+     * @return String ContentType header value
+     */
+    protected open suspend fun generateContentType(request: HttpRequest): String? =
+        request.body?.let { HttpContentType.APPLICATION_JSON }
+
+    protected open suspend fun generateRequestMessageRoutingHeaders() = currentRequestMessageRoutingHeadersOrNull()
+
+    protected abstract suspend fun doSend(request: HttpRequest): HttpResponse
 }

--- a/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/TransportClientBuilder.kt
+++ b/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/TransportClientBuilder.kt
@@ -1,14 +1,26 @@
 package com.izivia.ocpi.toolkit.transport
 
 interface BaseTransportClientBuilder<M, R> {
-    suspend fun buildFor(partnerId: String, module: M, role: R): TransportClient
-    fun build(baseUrl: String): TransportClient
+    suspend fun buildFor(partnerId: String, module: M, role: R, allowTokenA: Boolean = false): TransportClient
+    suspend fun buildFor(partnerId: String, baseUrl: String, allowTokenA: Boolean = false): TransportClient
+    suspend fun build(baseUrl: String, authToken: String): TransportClient
 }
 
 abstract class AbstractTransportClientBuilder<M, R>(
-    protected val partnerProvider: PartnerProviderInterface<M, R>,
+    private val partnerProvider: PartnerProviderInterface<M, R>,
 ) : BaseTransportClientBuilder<M, R> {
-    override suspend fun buildFor(partnerId: String, module: M, role: R): TransportClient {
-        return build(partnerProvider.getEndpointUrl(partnerId, module, role))
+    override suspend fun buildFor(partnerId: String, module: M, role: R, allowTokenA: Boolean): TransportClient {
+        return buildFor(
+            partnerId = partnerId,
+            baseUrl = partnerProvider.getEndpointUrl(partnerId, module, role),
+            allowTokenA = allowTokenA,
+        )
+    }
+
+    override suspend fun buildFor(partnerId: String, baseUrl: String, allowTokenA: Boolean): TransportClient {
+        return build(
+            baseUrl = baseUrl,
+            authToken = partnerProvider.getClientToken(partnerId, allowTokenA),
+        )
     }
 }

--- a/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/context/RequestMessageRoutingHeaders.kt
+++ b/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/context/RequestMessageRoutingHeaders.kt
@@ -1,5 +1,9 @@
-package com.izivia.ocpi.toolkit.common.context
+package com.izivia.ocpi.toolkit.transport.context
 
+import com.izivia.ocpi.toolkit.transport.domain.HttpHeaders.OCPI_FROM_COUNTRY_CODE
+import com.izivia.ocpi.toolkit.transport.domain.HttpHeaders.OCPI_FROM_PARTY_ID
+import com.izivia.ocpi.toolkit.transport.domain.HttpHeaders.OCPI_TO_COUNTRY_CODE
+import com.izivia.ocpi.toolkit.transport.domain.HttpHeaders.OCPI_TO_PARTY_ID
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
@@ -14,6 +18,16 @@ data class RequestMessageRoutingHeaders(
     val fromCountryCode: String? = null,
 ) : AbstractCoroutineContextElement(RequestMessageRoutingHeaders) {
     companion object Key : CoroutineContext.Key<RequestMessageRoutingHeaders>
+
+    fun toHttpHeaders(): Map<String, String> =
+        listOf(
+            OCPI_TO_PARTY_ID to toPartyId,
+            OCPI_TO_COUNTRY_CODE to toCountryCode,
+            OCPI_FROM_PARTY_ID to fromPartyId,
+            OCPI_FROM_COUNTRY_CODE to fromCountryCode,
+        )
+            .mapNotNull { entry -> entry.second?.let { entry.first to it } }
+            .toMap()
 }
 
 /**

--- a/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/context/ResponseMessageRoutingHeaders.kt
+++ b/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/context/ResponseMessageRoutingHeaders.kt
@@ -1,5 +1,9 @@
-package com.izivia.ocpi.toolkit.common.context
+package com.izivia.ocpi.toolkit.transport.context
 
+import com.izivia.ocpi.toolkit.transport.domain.HttpHeaders.OCPI_FROM_COUNTRY_CODE
+import com.izivia.ocpi.toolkit.transport.domain.HttpHeaders.OCPI_FROM_PARTY_ID
+import com.izivia.ocpi.toolkit.transport.domain.HttpHeaders.OCPI_TO_COUNTRY_CODE
+import com.izivia.ocpi.toolkit.transport.domain.HttpHeaders.OCPI_TO_PARTY_ID
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
@@ -26,6 +30,16 @@ data class ResponseMessageRoutingHeaders(
                 fromCountryCode = requestMessageRoutingHeaders.toCountryCode,
             )
     }
+
+    fun toHttpHeaders(): Map<String, String> =
+        listOf(
+            OCPI_TO_PARTY_ID to toPartyId,
+            OCPI_TO_COUNTRY_CODE to toCountryCode,
+            OCPI_FROM_PARTY_ID to fromPartyId,
+            OCPI_FROM_COUNTRY_CODE to fromCountryCode,
+        )
+            .mapNotNull { entry -> entry.second?.let { entry.first to it } }
+            .toMap()
 }
 
 /**

--- a/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/context/TokenHeader.kt
+++ b/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/context/TokenHeader.kt
@@ -1,4 +1,4 @@
-package com.izivia.ocpi.toolkit.common.context
+package com.izivia.ocpi.toolkit.transport.context
 
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext

--- a/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/domain/HttpContentType.kt
+++ b/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/domain/HttpContentType.kt
@@ -1,0 +1,5 @@
+package com.izivia.ocpi.toolkit.transport.domain
+
+object HttpContentType {
+    const val APPLICATION_JSON = "application/json"
+}

--- a/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/domain/HttpHeaders.kt
+++ b/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/domain/HttpHeaders.kt
@@ -1,0 +1,16 @@
+package com.izivia.ocpi.toolkit.transport.domain
+
+object HttpHeaders {
+    const val AUTHORIZATION = "Authorization"
+    const val X_REQUEST_ID = "X-Request-ID"
+    const val X_CORRELATION_ID = "X-Correlation-ID"
+    const val X_TOTAL_COUNT = "X-Total-Count"
+    const val X_LIMIT = "X-Limit"
+    const val LINK = "Link"
+    const val LOCATION = "Location"
+    const val CONTENT_TYPE = "Content-Type"
+    const val OCPI_TO_PARTY_ID = "OCPI-to-party-id"
+    const val OCPI_TO_COUNTRY_CODE = "OCPI-to-country-code"
+    const val OCPI_FROM_PARTY_ID = "OCPI-from-party-id"
+    const val OCPI_FROM_COUNTRY_CODE = "OCPI-from-country-code"
+}

--- a/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/domain/HttpRequest.kt
+++ b/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/domain/HttpRequest.kt
@@ -9,5 +9,46 @@ data class HttpRequest(
     val body: String? = null,
     val headers: Map<String, String> = emptyMap(),
 ) {
+
+    private val normalizedHeaders by lazy { headers.mapKeys { it.key.lowercase() } }
+
+    /**
+     * Returns the value of a header by its key. The key is not case-sensitive.
+     */
+    fun getHeader(key: String): String? = normalizedHeaders[key.lowercase()]
+
+    /**
+     * For debugging issues, OCPI implementations are required to include unique IDs via HTTP headers in every
+     * request/response
+     *
+     * - X-Request-ID: Every request SHALL contain a unique request ID, the response to this request SHALL contain the same
+     * ID.
+     * - X-Correlation-ID: Every request/response SHALL contain a unique correlation ID, every response to this request
+     * SHALL contain the same ID.
+     *
+     * This method should be called when responding to a request from a client.
+     */
+    fun getDebugHeaders() = listOfNotNull(
+        getHeader(HttpHeaders.X_REQUEST_ID)?.let { HttpHeaders.X_REQUEST_ID to it },
+        getHeader(HttpHeaders.X_CORRELATION_ID)?.let { HttpHeaders.X_CORRELATION_ID to it },
+    ).toMap()
+
     fun withHeaders(headers: Map<String, String> = emptyMap()) = copy(headers = headers)
+    fun withHeaderMixin(key: String, value: String) = copy(headers = headers.plus(key to value))
+    fun withHeadersMixin(extraHeaders: Map<String, String>) = copy(headers = headers.plus(extraHeaders))
+
+    fun withRequiredHeaders(
+        authToken: String,
+        requestId: String,
+        correlationId: String,
+        contentTypeHeader: String?,
+    ): HttpRequest =
+        withHeadersMixin(
+            buildMap {
+                put(HttpHeaders.AUTHORIZATION, authToken)
+                put(HttpHeaders.X_REQUEST_ID, requestId)
+                put(HttpHeaders.X_CORRELATION_ID, correlationId)
+                contentTypeHeader?.let { put(HttpHeaders.CONTENT_TYPE, it) }
+            },
+        )
 }


### PR DESCRIPTION
- cleanup transport client interface
- moves HttpRequest extensions to member methods
- single path for adding auth token
- single place for setting default headers