### PR TITLE
fix #193: Connector deserialization when tariffIds is absent from json

### DIFF
--- a/integrations/ocpi-toolkit-2.2.1-kotlinx-serialization/src/main/kotlin/com/izivia/ocpi/toolkit/integrations/kotlinx/serialization/serializers/TariffIdsSerializer.kt
+++ b/integrations/ocpi-toolkit-2.2.1-kotlinx-serialization/src/main/kotlin/com/izivia/ocpi/toolkit/integrations/kotlinx/serialization/serializers/TariffIdsSerializer.kt
@@ -1,5 +1,6 @@
 package com.izivia.ocpi.toolkit.integrations.kotlinx.serialization.serializers
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer
@@ -23,21 +24,22 @@ class SkipNullsListSerializer<T>(
         listSerializer.serialize(encoder, value)
     }
 
+    @OptIn(ExperimentalSerializationApi::class)
     override fun deserialize(decoder: Decoder): List<T>? {
+        if (!decoder.decodeNotNullMark()) return decoder.decodeNull()
+
         val jsonDecoder = decoder as? JsonDecoder
             ?: return listSerializer.deserialize(decoder)
 
         return when (val jsonElement = jsonDecoder.decodeJsonElement()) {
-            is JsonNull -> null
-            is JsonArray -> {
+            is JsonArray ->
                 jsonElement
                     .filterNot { it is JsonNull }
                     .map { element ->
                         jsonDecoder.json.decodeFromJsonElement(elementSerializer, element)
                     }
-            }
 
-            else -> throw SerializationException("Expected array or null for List")
+            else -> throw SerializationException("Expected array for List")
         }
     }
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/mappers/ConnectorMapperTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/mappers/ConnectorMapperTest.kt
@@ -21,4 +21,26 @@ class ConnectorMapperTest : TestWithSerializerProviders {
             ),
         ).isEqualTo(MappingData.connector)
     }
+
+    @ParameterizedTest
+    @MethodSource("getAvailableOcpiSerializers")
+    fun `should deserialize Connector with null tariffIds when tariff_ids field is absent`(serializer: OcpiSerializer) {
+        expectThat(
+            serializer.deserializeObject<Connector>(
+                JsonMappingData.connector(tariffIds = null),
+            ),
+        ).isEqualTo(MappingData.connector.copy(tariffIds = null))
+    }
+
+    @ParameterizedTest
+    @MethodSource("getAvailableOcpiSerializers")
+    fun `should deserialize Connector with null tariffIds when tariff_ids is explicitly null`(
+        serializer: OcpiSerializer,
+    ) {
+        expectThat(
+            serializer.deserializeObject<Connector>(
+                JsonMappingData.connector(tariffIds = "null"),
+            ),
+        ).isEqualTo(MappingData.connector.copy(tariffIds = null))
+    }
 }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/mappers/data/JsonMappingData.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/mappers/data/JsonMappingData.kt
@@ -1,7 +1,7 @@
 package com.izivia.ocpi.toolkit.mappers.data
 
 object JsonMappingData {
-    fun connector(tariffIds: String = "[\"tariffId\"]", connectorType: String = "\"IEC_62196_T2\"") = """
+    fun connector(tariffIds: String? = "[\"tariffId\"]", connectorType: String = "\"IEC_62196_T2\"") = """
         {
           "id" : "id",
           "standard" : $connectorType,
@@ -10,7 +10,7 @@ object JsonMappingData {
           "max_voltage" : 220,
           "max_amperage" : 16,
           "max_electric_power" : 7000,
-          "tariff_ids" : $tariffIds,
+          ${if (tariffIds != null) "\"tariff_ids\" : $tariffIds," else ""}
           "terms_and_conditions" : "termsAndConditions",
           "last_updated" : "2025-01-02T13:45:59.708Z"
         }


### PR DESCRIPTION
closes #193 

Updated `SkipNullsListSerializer.deserialize` to follow the standard `kotlinx.serialization` convention for nullable serializers: check `decoder.decodeNotNullMark()` before reading any token from the stream. When the decoder signals the value is `null` (either because the field is absent or because the JSON value is null), the method now returns null immediately without touching the stream.

```
  // Before
  return when (val jsonElement = jsonDecoder.decodeJsonElement()) {
      is JsonNull -> null
      is JsonArray -> { ... }
      else -> throw SerializationException("Expected array or null for List")
  }

  // After
  if (!decoder.decodeNotNullMark()) return decoder.decodeNull()
  return when (val jsonElement = jsonDecoder.decodeJsonElement()) {
      is JsonArray -> { ... }
      else -> throw SerializationException("Expected array for List")
  }

```

Added two new parameterized test cases in ConnectorMapperTest (run against all available serializers):
  - tariff_ids field entirely absent from JSON → tariffIds decoded as null
  - "tariff_ids": null explicit null in JSON → tariffIds decoded as null