### PR TITLE
fix(transport) #65: return HTTP 201 Created for newly created objects

### DIFF
--- a/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpRequest.kt
+++ b/ocpi-toolkit-2.2.1/src/main/kotlin/com/izivia/ocpi/toolkit/common/HttpRequest.kt
@@ -3,6 +3,7 @@ package com.izivia.ocpi.toolkit.common
 import com.izivia.ocpi.toolkit.serialization.mapper
 import com.izivia.ocpi.toolkit.serialization.serializeOcpiResponse
 import com.izivia.ocpi.toolkit.serialization.serializeOcpiResponseList
+import com.izivia.ocpi.toolkit.transport.context.currentHttpStatusOverrideOrNull
 import com.izivia.ocpi.toolkit.transport.context.currentResponseMessageRoutingHeadersOrNull
 import com.izivia.ocpi.toolkit.transport.domain.HttpException
 import com.izivia.ocpi.toolkit.transport.domain.HttpRequest
@@ -69,12 +70,10 @@ suspend inline fun <reified T> HttpRequest.respondNullableList(
 ) =
     defaultHeadersOrErrorHandling(now) {
         val result = fn()
+        val httpStatus = currentHttpStatusOverrideOrNull() ?: HttpStatus.OK
 
-        // TODO we are supposed to respond with a 201 CREATED if this is a newly added object
-        //      https://github.com/ocpi/ocpi/blob/v2.2.1-d2/status_codes.asciidoc
-        //      https://github.com/IZIVIA/ocpi-toolkit/issues/65
         HttpResponse(
-            status = HttpStatus.OK,
+            status = httpStatus,
             body = mapper.serializeOcpiResponseList<T>(
                 OcpiResponseBody(
                     data = result,
@@ -92,12 +91,10 @@ suspend inline fun <reified T> HttpRequest.respondNullableObject(
 ) =
     defaultHeadersOrErrorHandling(now) {
         val result = fn()
+        val httpStatus = currentHttpStatusOverrideOrNull() ?: HttpStatus.OK
 
-        // TODO we are supposed to respond with a 201 CREATED if this is a newly added object
-        //      https://github.com/ocpi/ocpi/blob/v2.2.1-d2/status_codes.asciidoc
-        //      https://github.com/IZIVIA/ocpi-toolkit/issues/65
         HttpResponse(
-            status = HttpStatus.OK,
+            status = httpStatus,
             body = mapper.serializeOcpiResponse<T>(
                 OcpiResponseBody(
                     data = result,

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpPutLocationCreatedTest.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/modules/locations/http/emsp/LocationsEmspHttpPutLocationCreatedTest.kt
@@ -1,0 +1,161 @@
+package com.izivia.ocpi.toolkit.modules.locations.http.emsp
+
+import com.izivia.ocpi.toolkit.common.TestTransportClient
+import com.izivia.ocpi.toolkit.common.TimeProvider
+import com.izivia.ocpi.toolkit.modules.buildHttpRequest
+import com.izivia.ocpi.toolkit.modules.locations.LocationsEmspServer
+import com.izivia.ocpi.toolkit.modules.locations.domain.*
+import com.izivia.ocpi.toolkit.modules.locations.repositories.LocationsEmspRepository
+import com.izivia.ocpi.toolkit.modules.locations.services.LocationsEmspService
+import com.izivia.ocpi.toolkit.modules.locations.services.LocationsEmspValidator
+import com.izivia.ocpi.toolkit.modules.versions.repositories.InMemoryVersionsRepository
+import com.izivia.ocpi.toolkit.samples.common.Http4kTransportServer
+import com.izivia.ocpi.toolkit.serialization.OcpiSerializer
+import com.izivia.ocpi.toolkit.serialization.mapper
+import com.izivia.ocpi.toolkit.serialization.serializeObject
+import com.izivia.ocpi.toolkit.transport.context.signalObjectCreated
+import com.izivia.ocpi.toolkit.transport.domain.HttpMethod
+import com.izivia.ocpi.toolkit.transport.domain.HttpStatus
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import java.time.Instant
+
+/**
+ * Verifies that PUT endpoints return HTTP 201 (Created) when the service signals
+ * that a new object was created, as required by the OCPI specification.
+ *
+ * @see <a href="https://github.com/ocpi/ocpi/blob/v2.2.1-d2/status_codes.asciidoc">OCPI Status Codes</a>
+ * @see <a href="https://github.com/IZIVIA/ocpi-toolkit/issues/65">Issue #65</a>
+ */
+class LocationsEmspHttpPutLocationCreatedTest : com.izivia.ocpi.toolkit.common.TestWithSerializerProviders {
+    @ParameterizedTest
+    @MethodSource("getAvailableOcpiSerializers")
+    fun `should return 201 Created when putLocation creates a new object`(serializer: OcpiSerializer) {
+        mapper = serializer
+        val slots = object {
+            var countryCode = slot<String>()
+            var partyId = slot<String>()
+            var locationId = slot<String>()
+            var location = slot<Location>()
+        }
+        val location = Location(
+            countryCode = "BE",
+            partyId = "BEC",
+            id = "LOC1",
+            name = "Gent Zuid",
+            address = "F.Rooseveltlaan 3A",
+            city = "Gent",
+            postalCode = "9000",
+            country = "BEL",
+            coordinates = GeoLocation("51.047599", "3.729944"),
+            parkingType = ParkingType.ON_STREET,
+            publish = true,
+            timeZone = "Europe/Brussels",
+            lastUpdated = Instant.parse("2015-06-29T20:39:09Z"),
+        )
+
+        // Repository that signals object creation via signalObjectCreated()
+        val srv = mockk<LocationsEmspRepository> {
+            coEvery {
+                putLocation(
+                    capture(slots.countryCode),
+                    capture(slots.partyId),
+                    capture(slots.locationId),
+                    capture(slots.location),
+                )
+            } coAnswers {
+                signalObjectCreated()
+                location
+            }
+        }.buildCreatedTestServer()
+
+        // when
+        val resp = srv.send(
+            buildHttpRequest(HttpMethod.PUT, "/locations/BE/BEC/LOC1", mapper.serializeObject(location)),
+        )
+
+        // then
+        expectThat(resp) {
+            get { status }.isEqualTo(HttpStatus.CREATED)
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("getAvailableOcpiSerializers")
+    fun `should return 200 OK when putLocation updates an existing object`(serializer: OcpiSerializer) {
+        mapper = serializer
+        val slots = object {
+            var countryCode = slot<String>()
+            var partyId = slot<String>()
+            var locationId = slot<String>()
+            var location = slot<Location>()
+        }
+        val location = Location(
+            countryCode = "BE",
+            partyId = "BEC",
+            id = "LOC1",
+            name = "Gent Zuid",
+            address = "F.Rooseveltlaan 3A",
+            city = "Gent",
+            postalCode = "9000",
+            country = "BEL",
+            coordinates = GeoLocation("51.047599", "3.729944"),
+            parkingType = ParkingType.ON_STREET,
+            publish = true,
+            timeZone = "Europe/Brussels",
+            lastUpdated = Instant.parse("2015-06-29T20:39:09Z"),
+        )
+
+        // Repository that does NOT signal creation (object already existed)
+        val srv = mockk<LocationsEmspRepository> {
+            coEvery {
+                putLocation(
+                    capture(slots.countryCode),
+                    capture(slots.partyId),
+                    capture(slots.locationId),
+                    capture(slots.location),
+                )
+            } coAnswers {
+                location
+            }
+        }.buildCreatedTestServer()
+
+        // when
+        val resp = srv.send(
+            buildHttpRequest(HttpMethod.PUT, "/locations/BE/BEC/LOC1", mapper.serializeObject(location)),
+        )
+
+        // then
+        expectThat(resp) {
+            get { status }.isEqualTo(HttpStatus.OK)
+        }
+    }
+}
+
+private val now = Instant.parse("2015-06-30T21:59:59Z")
+
+private fun LocationsEmspRepository.buildCreatedTestServer(): TestTransportClient {
+    val timeProvider = mockk<TimeProvider>()
+    every { timeProvider.now() } returns now
+
+    val transportServer = Http4kTransportServer("http://localhost:1234", 1234)
+
+    val repo = this
+    runBlocking {
+        LocationsEmspServer(
+            service = LocationsEmspValidator(LocationsEmspService(repo)),
+            timeProvider = timeProvider,
+            versionsRepository = InMemoryVersionsRepository(),
+            basePathOverride = "/locations",
+        ).registerOn(transportServer)
+    }
+
+    return TestTransportClient(transportServer.initRouterAndBuildClient())
+}

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Http4kTransportServer.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Http4kTransportServer.kt
@@ -80,7 +80,9 @@ class Http4kTransportServer(
                             val responseMessageRoutingHeaders = ResponseMessageRoutingHeaders
                                 .invertFromRequest(requestMessageRoutingHeaders)
 
-                            httpRequest to runBlocking(requestMessageRoutingHeaders + responseMessageRoutingHeaders + HttpStatusOverride()) {
+                            val coroutineContext =
+                                requestMessageRoutingHeaders + responseMessageRoutingHeaders + HttpStatusOverride()
+                            httpRequest to runBlocking(coroutineContext) {
                                 callback(httpRequest)
                             }
                         }

--- a/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Http4kTransportServer.kt
+++ b/ocpi-toolkit-2.2.1/src/test/kotlin/com/izivia/ocpi/toolkit/samples/common/Http4kTransportServer.kt
@@ -3,6 +3,7 @@ package com.izivia.ocpi.toolkit.samples.common
 import com.izivia.ocpi.toolkit.common.*
 import com.izivia.ocpi.toolkit.common.validation.toReadableString
 import com.izivia.ocpi.toolkit.transport.TransportServer
+import com.izivia.ocpi.toolkit.transport.context.HttpStatusOverride
 import com.izivia.ocpi.toolkit.transport.context.ResponseMessageRoutingHeaders
 import com.izivia.ocpi.toolkit.transport.domain.*
 import kotlinx.coroutines.runBlocking
@@ -79,7 +80,7 @@ class Http4kTransportServer(
                             val responseMessageRoutingHeaders = ResponseMessageRoutingHeaders
                                 .invertFromRequest(requestMessageRoutingHeaders)
 
-                            httpRequest to runBlocking(requestMessageRoutingHeaders + responseMessageRoutingHeaders) {
+                            httpRequest to runBlocking(requestMessageRoutingHeaders + responseMessageRoutingHeaders + HttpStatusOverride()) {
                                 callback(httpRequest)
                             }
                         }

--- a/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/context/HttpStatusOverride.kt
+++ b/transport/src/main/kotlin/com/izivia/ocpi/toolkit/transport/context/HttpStatusOverride.kt
@@ -1,0 +1,51 @@
+package com.izivia.ocpi.toolkit.transport.context
+
+import com.izivia.ocpi.toolkit.transport.domain.HttpStatus
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
+
+/**
+ * Allows service/repository implementations to override the HTTP status code of the response.
+ *
+ * This is primarily used to distinguish between HTTP 200 (OK) and HTTP 201 (Created) when handling
+ * PUT requests, as required by the OCPI specification:
+ * - HTTP 200: The object already existed and has successfully been updated.
+ * - HTTP 201: The object has been newly created in the server system.
+ *
+ * @see <a href="https://github.com/ocpi/ocpi/blob/v2.2.1-d2/status_codes.asciidoc">OCPI Status Codes</a>
+ */
+data class HttpStatusOverride(
+    var status: HttpStatus? = null,
+) : AbstractCoroutineContextElement(HttpStatusOverride) {
+    companion object Key : CoroutineContext.Key<HttpStatusOverride>
+}
+
+/**
+ * Signals that a new object was created, so the response should use HTTP 201 (Created)
+ * instead of the default 200 (OK).
+ *
+ * Call this from service or repository implementations inside PUT handlers when the object
+ * did not previously exist and was newly created.
+ *
+ * Usage:
+ * ```kotlin
+ * override suspend fun putLocation(...): Location {
+ *     val existing = repository.find(...)
+ *     val result = repository.save(location)
+ *     if (existing == null) {
+ *         signalObjectCreated()
+ *     }
+ *     return result
+ * }
+ * ```
+ */
+suspend fun signalObjectCreated() {
+    coroutineContext[HttpStatusOverride]?.status = HttpStatus.CREATED
+}
+
+/**
+ * Retrieves the HTTP status override from the current coroutine context, if present.
+ */
+suspend fun currentHttpStatusOverrideOrNull(): HttpStatus? =
+    coroutineContext[HttpStatusOverride]?.status


### PR DESCRIPTION
The OCPI spec requires that PUT endpoints return HTTP 201 when a new object is created, and 200 when an existing object is updated (https://github.com/ocpi/ocpi/blob/v2.2.1-d2/status_codes.asciidoc). Right now the toolkit always returns 200 regardless.

I went with a coroutine context approach since it fits naturally with how the toolkit already handles `ResponseMessageRoutingHeaders` and `TokenHeader`. The idea is:

1. A new `HttpStatusOverride` coroutine context element gets installed by `TransportServer` implementations alongside the existing context elements
2. Service/repository implementations call `signalObjectCreated()` when they determine the object is new
3. `respondNullableObject` and `respondNullableList` check for this override and return 201 if set, 200 otherwise

This keeps everything backward-compatible — existing code doesn't change behavior at all. Only services that explicitly opt in by calling `signalObjectCreated()` will see the 201 response.

I also updated the test `Http4kTransportServer` to install the context element and added tests covering both the creation (201) and update (200) paths.

Fixes #65