### PR TITLE
fix(publish): #197 add dedicated R-*-transport tag to avoid double-publishing shared modules

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: OCPI Publish
 on:
     push:
         tags:
+            - "R-*-transport"
             - "R-*-ocpi221"
             - "R-*-ocpi211"
 
@@ -31,8 +32,8 @@ jobs:
                 with:
                     cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
-            -   name: Publish OCPI 2.2.1 module pack
-                if: ${{ endsWith(github.ref_name, '-ocpi221') }}
+            -   name: Publish transport module pack
+                if: ${{ endsWith(github.ref_name, '-transport') }}
                 env:
                     VERSION: ${{ github.ref }}
                     SONATYPE_USERNAME: ${{ secrets.DELIVERY_SONATYPE_USERNAME }}
@@ -43,6 +44,18 @@ jobs:
                     ./gradlew
                     :transport:publishToSonatype
                     :annotation-processor:publishToSonatype
+                    closeAndReleaseSonatypeStagingRepository
+
+            -   name: Publish OCPI 2.2.1 module pack
+                if: ${{ endsWith(github.ref_name, '-ocpi221') }}
+                env:
+                    VERSION: ${{ github.ref }}
+                    SONATYPE_USERNAME: ${{ secrets.DELIVERY_SONATYPE_USERNAME }}
+                    SONATYPE_PASSWORD: ${{ secrets.DELIVERY_SONATYPE_PASSWORD }}
+                    GPG_PRIVATE_KEY: ${{ secrets.DELIVERY_GPG_SECRET_KEY }}
+                    GPG_PASSPHRASE: ${{ secrets.DELIVERY_GPG_KEY_PASSPHRASE }}
+                run: >-
+                    ./gradlew
                     :ocpi-toolkit-2.2.1:publishToSonatype
                     :integrations:ocpi-toolkit-2.2.1-jackson:publishToSonatype
                     :integrations:ocpi-toolkit-2.2.1-kotlinx-serialization:publishToSonatype
@@ -58,12 +71,22 @@ jobs:
                     GPG_PASSPHRASE: ${{ secrets.DELIVERY_GPG_KEY_PASSPHRASE }}
                 run: >-
                     ./gradlew
-                    :transport:publishToSonatype
-                    :annotation-processor:publishToSonatype
                     :ocpi-toolkit-2.1.1:publishToSonatype
                     :integrations:ocpi-toolkit-2.1.1-jackson:publishToSonatype
                     :integrations:ocpi-toolkit-2.1.1-kotlinx-serialization:publishToSonatype
                     closeAndReleaseSonatypeStagingRepository
+
+            -   name: Create a GH release (transport)
+                if: ${{ endsWith(github.ref_name, '-transport') }}
+                env:
+                    GIT_TAG: ${{ github.ref }}
+                    VERSION: ${{ github.ref_name }}
+                    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                run: |-
+                    gh release create "$GIT_TAG" \
+                        --generate-notes \
+                        --title "Version ${VERSION#R-}" \
+                        transport/build/libs/*.jar
 
             -   name: Create a GH release (2.2.1)
                 if: ${{ endsWith(github.ref_name, '-ocpi221') }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
 
 val versionNumber = System.getenv("VERSION")
     ?.substringAfter("R-")
-    ?.replace(Regex("-ocpi\\d+$"), "")
+    ?.replace(Regex("-(ocpi\\d+|transport)$"), "")
     ?: "0.0.15"
 
 println("building current version: $versionNumber")


### PR DESCRIPTION
closes #197 which prevent publishing artifacts

transport and annotation-processor are shared by both ocpi221 and ocpi211 packs. Publishing both packs with the same version number caused Sonatype to reject the second upload (republishing a released artifact is forbidden).

- Add R-*-transport trigger and dedicated publish/release steps
- Remove :transport and :annotation-processor from ocpi221/ocpi211 steps
- Fix version regex in build.gradle.kts to strip -transport suffix